### PR TITLE
Fix broken savestates.

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -237,7 +237,7 @@ void retro_reset(void)
 
 size_t retro_serialize_size(void)
 {
-   return 0x40000;
+   return 0x100000;
 }
 
 bool retro_serialize(void *data, size_t size)


### PR DESCRIPTION
0x40000 (256KBytes) is way too small. Some MSX machines can have a minimum of 512KBytes of RAM (unsure how much video RAM at present, will open another pull request in the future that makes this dynamic), so I increased the size four-fold to 1 MByte to be safe.