### PR TITLE
Use git version as library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 TARGET_NAME := fmsx
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 DEBUG     = 0
 PATCH_Z80 = 0

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,4 +1,8 @@
 LOCAL_PATH := $(call my-dir)
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 include $(CLEAR_VARS)
 

--- a/libretro.c
+++ b/libretro.c
@@ -121,7 +121,10 @@ keymap_t joymap[] =
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "fMSX";
-   info->library_version = "3.9";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version = "3.9" GIT_VERSION;
    info->need_fullpath = true;
    info->block_extract = false;
    info->valid_extensions = "rom|mx1|mx2";


### PR DESCRIPTION
This patch makes this core report the git version as its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.