### PR TITLE
Exposed RAM and VRAM memory configuration settings

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -493,7 +493,7 @@ static void check_variables(void)
    else
    {
       Mode |= MSX_MSX2P;
-      ModeRAM = 8;
+      ModeRAM = 16;
       ModeVRAM = 8;
    }
 

--- a/libretro.c
+++ b/libretro.c
@@ -401,7 +401,7 @@ void retro_set_environment(retro_environment_t cb)
       { "fmsx_video_mode", "MSX Video Mode; NTSC|PAL" },
       { "fmsx_mapper_type_mode", "MSX Mapper Type Mode; Guess Mapper Type A|Guess Mapper Type B" },
       { "fmsx_ram_pages", "Main Memory; Auto,64KB,128KB,256KB,512KB" },
-      { "fmsx_vram_pages", "Video Memory; Auto,32KB,64KB,128KB,256KB,512KB" },
+      { "fmsx_vram_pages", "Video Memory; Auto,32KB,64KB,128KB,192KB" },
       { NULL, NULL },
    };
 
@@ -487,7 +487,7 @@ static void check_variables(void)
          ModeVRAM = 8;
       else if (strcmp(var.value, "MSX2+") == 0)
          Mode |= MSX_MSX2P;
-         ModeRAM = 8;
+         ModeRAM = 16;
          ModeVRAM = 8;
    }
    else
@@ -561,10 +561,8 @@ static void check_variables(void)
          VRAMPages = 4;
       else if (strcmp(var.value, "128KB") == 0)
          VRAMPages = 8;
-      else if (strcp(var.value, "256KB") == 0)
-         VRAMPages = 16;
-      else if (strcmp(var.value, "512KB") == 0)
-         VRAMPages = 32;
+      else if (strcp(var.value, "192KB") == 0)
+         VRAMPages = 12;
    }
    else
    {

--- a/libretro.c
+++ b/libretro.c
@@ -400,6 +400,8 @@ void retro_set_environment(retro_environment_t cb)
       { "fmsx_mode", "MSX Mode; MSX2+|MSX1|MSX2" },
       { "fmsx_video_mode", "MSX Video Mode; NTSC|PAL" },
       { "fmsx_mapper_type_mode", "MSX Mapper Type Mode; Guess Mapper Type A|Guess Mapper Type B" },
+      { "fmsx_ram_pages", "Main Memory; 64KB,128KB,256KB,512KB" },
+      { "fmsx_vram_pages", "Video Memory; 32KB,64KB,128KB,256KB,512KB" },
       { NULL, NULL },
    };
 
@@ -513,6 +515,46 @@ static void check_variables(void)
    else
    {
       Mode |= MSX_GUESSA;
+   }
+
+   var.key = "fmsx_ram_pages";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "64KB") == 0)
+         RAMPages = 4;
+      else if (strcmp(var.value, "128KB") == 0)
+         RAMPages = 8;
+      else if (strcmp(var.value, "256KB") == 0)
+         RAMPages = 16;
+      else if (strcmp(var.value, "512KB") == 0)
+         RAMPages = 32;
+   }
+   else
+   {
+      RAMPages = 4;
+   }
+
+   var.key = "fmsx_vram_pages";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "32KB") == 0)
+         VRAMPages = 2;
+      else if (strcmp(var.value, "64KB") == 0)
+         VRAMPages = 4;
+      else if (strcmp(var.value, "128KB") == 0)
+         VRAMPages = 8;
+      else if (strcp(var.value, "256KB") == 0)
+         VRAMPages = 16;
+      else if (strcmp(var.value, "512KB") == 0)
+         VRAMPages = 32;
+   }
+   else
+   {
+      VRAMPages = 2;
    }
 }
 

--- a/libretro.c
+++ b/libretro.c
@@ -400,8 +400,8 @@ void retro_set_environment(retro_environment_t cb)
       { "fmsx_mode", "MSX Mode; MSX2+|MSX1|MSX2" },
       { "fmsx_video_mode", "MSX Video Mode; NTSC|PAL" },
       { "fmsx_mapper_type_mode", "MSX Mapper Type Mode; Guess Mapper Type A|Guess Mapper Type B" },
-      { "fmsx_ram_pages", "Main Memory; 64KB,128KB,256KB,512KB" },
-      { "fmsx_vram_pages", "Video Memory; 32KB,64KB,128KB,256KB,512KB" },
+      { "fmsx_ram_pages", "Main Memory; Auto,64KB,128KB,256KB,512KB" },
+      { "fmsx_vram_pages", "Video Memory; Auto,32KB,64KB,128KB,256KB,512KB" },
       { NULL, NULL },
    };
 
@@ -472,19 +472,29 @@ static void check_variables(void)
    var.value = NULL;
 
    Mode = 0;
+   ModeRAM = 0;
+   ModeVRAM = 0;
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "MSX1") == 0)
          Mode |= MSX_MSX1;
+         ModeRAM = 4;
+         ModeVRAM = 2;
       else if (strcmp(var.value, "MSX2") == 0)
          Mode |= MSX_MSX2;
+         ModeRAM = 8;
+         ModeVRAM = 8;
       else if (strcmp(var.value, "MSX2+") == 0)
          Mode |= MSX_MSX2P;
+         ModeRAM = 8;
+         ModeVRAM = 8;
    }
    else
    {
       Mode |= MSX_MSX2P;
+      ModeRAM = 8;
+      ModeVRAM = 8;
    }
 
    var.key = "fmsx_video_mode";
@@ -522,7 +532,9 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (strcmp(var.value, "64KB") == 0)
+      if (strcmp(var.value, "Auto") == 0)
+         RAMPages = ModeRAM;
+      else if (strcmp(var.value, "64KB") == 0)
          RAMPages = 4;
       else if (strcmp(var.value, "128KB") == 0)
          RAMPages = 8;
@@ -533,7 +545,7 @@ static void check_variables(void)
    }
    else
    {
-      RAMPages = 4;
+      RAMPages = ModeRAM;
    }
 
    var.key = "fmsx_vram_pages";
@@ -541,7 +553,9 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (strcmp(var.value, "32KB") == 0)
+      if (strcmp(var.value, "Auto") == 0)
+         VRAMPages = ModeVRAM;
+      else if (strcmp(var.value, "32KB") == 0)
          VRAMPages = 2;
       else if (strcmp(var.value, "64KB") == 0)
          VRAMPages = 4;
@@ -554,7 +568,7 @@ static void check_variables(void)
    }
    else
    {
-      VRAMPages = 2;
+      VRAMPages = ModeVRAM;
    }
 }
 


### PR DESCRIPTION
Adds two items to the runtime options menu:

Main Memory = Auto,64KB,128KB,256KB,512KB  
Video Memory = Auto,32KB,64KB,128KB,192KB

Where "Auto" signifies default amounts, relative to mode:

MSX1 = RAM 64KB, VRAM 32KB  
MSX2 = RAM 128KB, VRAM 128KB  
MSX2+ = RAM 256KB, VRAM 128KB
