### PR TITLE
Fixed menu option labels

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -324,7 +324,7 @@ static void set_input_descriptors(void)
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,          "F1" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,              "F2" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,              "F3" },
-      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,          "Grap192h" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,          "Graph" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,           "Ctrl" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,             "F5" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,         "Escape" },

--- a/libretro.c
+++ b/libretro.c
@@ -400,8 +400,8 @@ void retro_set_environment(retro_environment_t cb)
       { "fmsx_mode", "MSX Mode; MSX2+|MSX1|MSX2" },
       { "fmsx_video_mode", "MSX Video Mode; NTSC|PAL" },
       { "fmsx_mapper_type_mode", "MSX Mapper Type Mode; Guess Mapper Type A|Guess Mapper Type B" },
-      { "fmsx_ram_pages", "Main Memory; Auto|64KB|128KB|256KB|512KB" },
-      { "fmsx_vram_pages", "Video Memory; Auto|32KB|64KB|128KB|192KB" },
+      { "fmsx_ram_pages", "MSX Main Memory; Auto|64KB|128KB|256KB|512KB" },
+      { "fmsx_vram_pages", "MSX Video Memory; Auto|32KB|64KB|128KB|192KB" },
       { NULL, NULL },
    };
 

--- a/libretro.c
+++ b/libretro.c
@@ -400,8 +400,8 @@ void retro_set_environment(retro_environment_t cb)
       { "fmsx_mode", "MSX Mode; MSX2+|MSX1|MSX2" },
       { "fmsx_video_mode", "MSX Video Mode; NTSC|PAL" },
       { "fmsx_mapper_type_mode", "MSX Mapper Type Mode; Guess Mapper Type A|Guess Mapper Type B" },
-      { "fmsx_ram_pages", "Main Memory; Auto,64KB,128KB,256KB,512KB" },
-      { "fmsx_vram_pages", "Video Memory; Auto,32KB,64KB,128KB,192KB" },
+      { "fmsx_ram_pages", "Main Memory; Auto|64KB|128KB|256KB|512KB" },
+      { "fmsx_vram_pages", "Video Memory; Auto|32KB|64KB|128KB|192KB" },
       { NULL, NULL },
    };
 


### PR DESCRIPTION
Apologies, this is fixing the last of the changes I had begun before I could test properly.

Prior to this the menu options use the wrong separators.

Also corrects a typo that resulted from me typing a search term "192" into the document