### PR TITLE
Finalize 4.9 update

### DIFF
--- a/EMULib/AY8910.c
+++ b/EMULib/AY8910.c
@@ -6,7 +6,7 @@
 /** produced by General Instruments, Yamaha, etc. See       **/
 /** AY8910.h for declarations.                              **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/AY8910.c
+++ b/EMULib/AY8910.c
@@ -72,6 +72,9 @@ void Reset8910(AY8910 *D,int ClockHz,int First)
   SetSound(4+First,SND_NOISE);
   SetSound(5+First,SND_NOISE);
 
+  /* Configure noise generator */
+  SetNoise(0x10000,16,14);
+
   /* Silence all channels */
   for(J=0;J<AY8910_CHANNELS;J++)
   {
@@ -293,7 +296,7 @@ void Sync8910(AY8910 *D,byte Sync)
     J = (D->Freq[3]? D->Volume[3]:0)
       + (D->Freq[4]? D->Volume[4]:0)
       + (D->Freq[5]? D->Volume[5]:0);
-    if(J) Drum(DRM_MIDI|28,(J+2)/3);
+    if(J) Drum(DRM_MIDI|28,J>255? 255:J);
   }
 
   if(Sync!=AY8910_FLUSH) D->Sync=Sync;

--- a/EMULib/AY8910.h
+++ b/EMULib/AY8910.h
@@ -37,7 +37,7 @@ typedef struct
   byte R[16];                  /* PSG registers contents     */
   int Freq[AY8910_CHANNELS];   /* Frequencies (0 for off)    */
   int Volume[AY8910_CHANNELS]; /* Volumes (0..255)           */
-  int Clock;                   /* Base clock used by PSG     */
+  int Clock;                   /* Base clock rate (Fin/16)   */
   int First;                   /* First used Sound() channel */
   byte Changed;                /* Bitmap of changed channels */
   byte Sync;                   /* AY8910_SYNC/AY8910_ASYNC   */

--- a/EMULib/AY8910.h
+++ b/EMULib/AY8910.h
@@ -6,7 +6,7 @@
 /** produced by General Instruments, Yamaha, etc. See       **/
 /** AY8910.c for the actual code.                           **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/EMULib.c
+++ b/EMULib/EMULib.c
@@ -112,9 +112,6 @@ void SetVideo(Image *Img,int X,int Y,int W,int H)
   VideoY   = Y<0? 0:Y>=Img->H? Img->H-1:Y;
   VideoW   = VideoX+W>Img->W? Img->W-VideoX:W;
   VideoH   = VideoY+H>Img->H? Img->H-VideoY:H;
-#ifdef WINDOWS
-  FreeImage(&BigScreen);
-#endif
 }
 
 /** WaitJoystick() *******************************************/

--- a/EMULib/EMULib.c
+++ b/EMULib/EMULib.c
@@ -5,7 +5,7 @@
 /** This file contains platform-independent implementation  **/
 /** part of the emulation library.                          **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/EMULib.h
+++ b/EMULib/EMULib.h
@@ -35,11 +35,18 @@
 #define EFF_SHOWFPS    0x0200  /* Show frames-per-sec count  */
 #define EFF_LCDLINES   0x0400  /* Apply LCD scanlines effect */
 #define EFF_VKBD       0x0800  /* Draw virtual keyboard      */
+#define EFF_SOFTEN2    0x1000  /* Softening algorithm select */
 #define EFF_FULLJOY    0x2000  /* Use full screen controls   */
 #define EFF_TILTJOY    0x4000  /* Use accelerometer controls */
 #define EFF_PENJOY     0x8000  /* Use touchpad controls      */
 #define EFF_VSYNC     0x10000  /* Wait for VBlanks           */
 #define EFF_DIRECT    0x20000  /* Copy whole VideoImg        */
+#define EFF_CMYMASK   0x40000  /* Apply vertical CMY mask    */
+#define EFF_RGBMASK   0x80000  /* Apply vertical RGB mask    */
+#define EFF_SOFTEN3 0x1000000  /* Softening algorithm select */
+#define EFF_MONO    0x2000000  /* Apply monochrome color     */
+#define EFF_VIGNETTE 0x4000000 /* Apply CRT-like vignetting  */
+#define EFF_4X3     0x8000000  /* Stretch video to 4x3 ratio */
 #if defined(ANDROID)
 #define EFF_FIXFFWD  0x100000  /* Persistent FFWD button     */
 #define EFF_GLES     0x200000  /* OpenGLES video rendering   */
@@ -58,6 +65,22 @@
 #elif defined(UNIX)
 #define EFF_VARBPP   0x200000  /* X11 determines Image depth */
 #endif
+
+#define EFF_SOFTEN_ALL (EFF_SOFTEN|EFF_SOFTEN2|EFF_SOFTEN3)
+#define EFF_2XSAI      (EFF_SOFTEN)
+#define EFF_EPX        (EFF_SOFTEN2)
+#define EFF_EAGLE      (EFF_SOFTEN|EFF_SOFTEN2)
+#define EFF_SCALE2X    (EFF_SOFTEN3)
+#define EFF_HQ4X       (EFF_SOFTEN|EFF_SOFTEN3)
+#define EFF_NEAREST    (EFF_SOFTEN2|EFF_SOFTEN3)
+
+#define EFF_RASTER_ALL (EFF_TVLINES|EFF_LCDLINES)
+#define EFF_RASTER     (EFF_TVLINES|EFF_LCDLINES)
+
+#define EFF_MASK_ALL   (EFF_CMYMASK|EFF_RGBMASK|EFF_MONO)
+#define EFF_GREEN      (EFF_MONO|EFF_CMYMASK)
+#define EFF_AMBER      (EFF_MONO|EFF_RGBMASK)
+#define EFF_SEPIA      (EFF_MONO|EFF_CMYMASK|EFF_RGBMASK)
 
 /** Button Bits **********************************************/
 /** Bits returned by GetJoystick() and WaitJoystick().      **/
@@ -244,11 +267,59 @@ void LcdizeImage(Image *Img,int X,int Y,int W,int H);
 /*************************************************************/
 void RasterizeImage(Image *Img,int X,int Y,int W,int H);
 
+/** CMYizeImage() ********************************************/
+/** Apply vertical CMY stripes to the image.                **/
+/*************************************************************/
+void CMYizeImage(Image *Img,int X,int Y,int W,int H);
+
+/** RGBizeImage() ********************************************/
+/** Apply vertical RGB stripes to the image.                **/
+/*************************************************************/
+void RGBizeImage(Image *Img,int X,int Y,int W,int H);
+
+/** MonoImage() **********************************************/
+/** Turn image into monochrome.                             **/
+/*************************************************************/
+void MonoImage(Image *Img,int X,int Y,int W,int H);
+
+/** SepiaImage() *********************************************/
+/** Turn image into sepia tones.                            **/
+/*************************************************************/
+void SepiaImage(Image *Img,int X,int Y,int W,int H);
+
+/** GreenImage() *********************************************/
+/** Simulate green CRT phosphor.                            **/
+/*************************************************************/
+void GreenImage(Image *Img,int X,int Y,int W,int H);
+
+/** AmberImage() *********************************************/
+/** Simulate amber CRT phosphor.                            **/
+/*************************************************************/
+void AmberImage(Image *Img,int X,int Y,int W,int H);
+
 /** SoftenImage() ********************************************/
 /** Uses softening algorithm to interpolate image Src into  **/
 /** a bigger image Dst.                                     **/
 /*************************************************************/
 void SoftenImage(Image *Dst,const Image *Src,int X,int Y,int W,int H);
+
+/** SoftenSCALE2X() ******************************************/
+/** Uses SCALE2X softening algorithm to interpolate image   **/
+/** Src into a bigger image Dst.                            **/
+/*************************************************************/
+void SoftenSCALE2X(Image *Dst,const Image *Src,int X,int Y,int W,int H);
+
+/** SoftenEPX() **********************************************/
+/** Uses EPX softening algorithm to interpolate image Src   **/
+/** into a bigger image Dst.                                **/
+/*************************************************************/
+void SoftenEPX(Image *Dst,const Image *Src,int X,int Y,int W,int H);
+
+/** SoftenEAGLE() ********************************************/
+/** Uses EAGLE softening algorithm to interpolate image Src **/
+/** into a bigger image Dst.                                **/
+/*************************************************************/
+void SoftenEAGLE(Image *Dst,const Image *Src,int X,int Y,int W,int H);
 
 /** ClearImage() *********************************************/
 /** Clear image with a given color.                         **/
@@ -303,6 +374,11 @@ void SetPalette(pixel N,unsigned char R,unsigned char G,unsigned char B);
 /** Get the amount of free samples in the audio buffer.     **/
 /*************************************************************/
 unsigned int GetFreeAudio(void);
+
+/** GetTotalAudio() ******************************************/
+/** Get total amount of samples in the audio buffer.        **/
+/*************************************************************/
+unsigned int GetTotalAudio(void);
 
 /** WriteAudio() *********************************************/
 /** Write up to a given number of samples to audio buffer.  **/
@@ -390,6 +466,12 @@ int ProcessEvents(int Wait);
 /** Set visual effects applied to video in ShowVideo().     **/
 /*************************************************************/
 void SetEffects(unsigned int NewEffects);
+
+/** ParseEffects() *******************************************/
+/** Parse command line visual effect options, removing them **/
+/** from Args[] and applying to the initial Effects value.  **/
+/*************************************************************/
+unsigned int ParseEffects(char *Args[],unsigned int Effects);
 
 /** GetFilePath() ********************************************/
 /** Extracts pathname from filename and returns a pointer   **/

--- a/EMULib/EMULib.h
+++ b/EMULib/EMULib.h
@@ -5,7 +5,7 @@
 /** This file contains platform-independent definitions and **/
 /** declarations for the emulation library.                 **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/FDIDisk.c
+++ b/EMULib/FDIDisk.c
@@ -6,7 +6,7 @@
 /** disk images in various formats. The internal format is  **/
 /** always .FDI. See FDIDisk.h for declarations.            **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2007-2014                 **/
+/** Copyright (C) Marat Fayzullin 2007-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/FDIDisk.h
+++ b/EMULib/FDIDisk.h
@@ -6,7 +6,7 @@
 /** disk images in various formats. The internal format is  **/
 /** always .FDI. See FDIDisk.c for the actual code.         **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2007-2014                 **/
+/** Copyright (C) Marat Fayzullin 2007-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Floppy.c
+++ b/EMULib/Floppy.c
@@ -185,13 +185,13 @@ int DSKFile(byte *Dsk,const char *FileName)
 /*************************************************************/
 const char *DSKFileName(const byte *Dsk,int ID)
 {
-  const unsigned char *Name;
+  const char *Name;
 
   /* Can't have ID that is out of bounds */
   if((ID<1)||(ID>DSK_DIR_SIZE)) return(0);
   /* Return file name */
-  Name=DIRENTRY(Dsk,ID-1);
-  return(!Name[0]||(Name[0]==0xE5)? 0:Name);
+  Name=(const char *)DIRENTRY(Dsk,ID-1);
+  return(!Name[0]||(Name[0]==(char)0xE5)? 0:Name);
 }
 
 /** DSKFileSize() ********************************************/
@@ -371,7 +371,8 @@ int DSKDelete(byte *Dsk,int ID)
 /*************************************************************/
 byte *DSKLoad(const char *Name,byte *Dsk)
 {
-  byte *Dsk1,*Buf,FN[32],*Path;
+  byte *Dsk1,*Buf;
+  char *Path,FN[32];
   struct stat FS;
   RFILE *F;
   struct RDIR *D;
@@ -457,7 +458,7 @@ byte *DSKLoad(const char *Name,byte *Dsk)
 const byte *DSKSave(const char *Name,const byte *Dsk)
 {
   const char *T;
-  byte *Path,*P;
+  char *Path,*P;
   struct stat FS;
   RFILE *F;
   int J,I,K;

--- a/EMULib/Floppy.c
+++ b/EMULib/Floppy.c
@@ -5,7 +5,7 @@
 /** This file implements functions to operate on 720kB      **/
 /** floppy disk images. See Floppy.h for declarations.      **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2004-2014                 **/
+/** Copyright (C) Marat Fayzullin 2004-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Floppy.h
+++ b/EMULib/Floppy.h
@@ -5,7 +5,7 @@
 /** This file declares functions to operate on 720kB        **/
 /** floppy disk images. See Floppy.c for implementation.    **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2004-2014                 **/
+/** Copyright (C) Marat Fayzullin 2004-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/I8255.c
+++ b/EMULib/I8255.c
@@ -6,7 +6,7 @@
 /** port interface (PPI) chip from Intel. See I8255.h for   **/
 /** declarations.                                           **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2001-2014                 **/
+/** Copyright (C) Marat Fayzullin 2001-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/I8255.h
+++ b/EMULib/I8255.h
@@ -6,7 +6,7 @@
 /** port interface (PPI) chip from Intel. See I8255.h for   **/
 /** the actual code.                                        **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2001-2014                 **/
+/** Copyright (C) Marat Fayzullin 2001-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/MIDIFreq.h
+++ b/EMULib/MIDIFreq.h
@@ -6,7 +6,7 @@
 /** into MIDI octave/note numbers. It is included from the  **/
 /** Sound.c and SndWin.c files.                             **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/SCC.c
+++ b/EMULib/SCC.c
@@ -5,7 +5,7 @@
 /** This file contains emulation for the SCC sound chip     **/
 /** produced by Konami.                                     **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/SCC.h
+++ b/EMULib/SCC.h
@@ -5,7 +5,7 @@
 /** This file contains definitions and declarations for     **/
 /** routines in SCC.c.                                      **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Sound.c
+++ b/EMULib/Sound.c
@@ -6,7 +6,7 @@
 /** and functions needed to log soundtrack into a MIDI      **/
 /** file. See Sound.h for declarations.                     **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Sound.c
+++ b/EMULib/Sound.c
@@ -43,13 +43,13 @@ static const struct { byte Note;word Wheel; } Freqs[4096] =
 #include "MIDIFreq.h"
 };
 
-static const int Programs[5] =
+static const int Programs[] =
 {
   80,  /* SND_MELODIC/SND_RECTANGLE */
   80,  /* SND_TRIANGLE */
   122, /* SND_NOISE */
   122, /* SND_PERIODIC */
-  80   /* SND_WAVE */
+  80,  /* SND_WAVE */
 };
 
 static struct
@@ -58,24 +58,25 @@ static struct
   int Note;
   int Pitch;
   int Level;
+  int Power;
 } MidiCH[MIDI_CHANNELS] =
 {
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 },
-  { -1,-1,-1,-1 }
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 },
+  { -1,-1,-1,-1,256 }
 };
 
 static struct
@@ -112,7 +113,9 @@ static struct
 
 /** RenderAudio() Variables *******************************************/
 static int SndRate    = 0;        /* Sound rate (0=Off)               */
-static int NoiseGen   = 1;        /* Noise generator seed             */
+static int NoiseGen   = 0x10000;  /* Noise generator seed             */
+static int NoiseOut   = 16;       /* NoiseGen bit used for output     */
+static int NoiseXor   = 14;       /* NoiseGen bit used for XORing     */
 int MasterSwitch      = 0xFFFF;   /* Switches to turn channels on/off */
 int MasterVolume      = 192;      /* Master volume                    */
 
@@ -153,12 +156,19 @@ void Sound(int Channel,int Freq,int Volume)
 {
   /* All parameters have to be valid */
   if((Channel<0)||(Channel>=SND_CHANNELS)) return;
-  Freq   = Freq<0? 0:Freq>20000? 0:Freq;
+  Freq   = Freq<0? 0:Freq;
   Volume = Volume<0? 0:Volume>255? 255:Volume;
 
-  /* Modify wave channel */ 
+  /* Modify channel parameters */ 
   WaveCH[Channel].Volume = Volume;
   WaveCH[Channel].Freq   = Freq;
+
+  /* When disabling sound, reset waveform */
+  if(!Freq||!Volume)
+  {
+    WaveCH[Channel].Pos    = 0;
+    WaveCH[Channel].Count  = 0;
+  }
 
   /* Log sound to MIDI file */
   MIDISound(Channel,Freq,Volume);
@@ -209,6 +219,18 @@ void SetChannels(int Volume,int Switch)
   MasterSwitch = Switch&((1<<SND_CHANNELS)-1);
 }
 
+/** SetNoise() ***********************************************/
+/** Initialize random noise generator to the given Seed and **/
+/** then take random output from OUTBit and XOR it with     **/
+/** XORBit.                                                 **/
+/*************************************************************/
+void SetNoise(int Seed,int OUTBit,int XORBit)
+{
+  NoiseGen = Seed;
+  NoiseOut = OUTBit;
+  NoiseXor = XORBit;
+}
+
 /** SetWave() ************************************************/
 /** Set waveform for a given channel. The channel will be   **/
 /** marked with sound type SND_WAVE. Set Rate=0 if you want **/
@@ -217,6 +239,8 @@ void SetChannels(int Volume,int Switch)
 /*************************************************************/
 void SetWave(int Channel,const signed char *Data,int Length,int Rate)
 {
+  unsigned int I,J;
+
   /* Channel and waveform length have to be valid */
   if((Channel<0)||(Channel>=SND_CHANNELS)||(Length<=0)) return;
 
@@ -229,7 +253,19 @@ void SetWave(int Channel,const signed char *Data,int Length,int Rate)
   WaveCH[Channel].Data   = Data;
 
   /* Log instrument change to MIDI file */
-  MIDISetSound(Channel,Rate? -1:SND_MELODIC);
+  MIDISetSound(Channel,Rate? -1:SND_WAVE);
+
+  /* Compute overall waveform power for MIDI */
+  if(Rate) I=0;
+  else
+  {
+    for(J=I=0;J<Length;++J) I+=Data[J]>0? Data[J]:-Data[J];
+    I = (I<<1)/Length;
+    I = I>256? 256:I;
+  }
+
+  /* Will use power value when computing MIDI volume */
+  MidiCH[Channel].Power = I;
 }
 
 /** GetWave() ************************************************/
@@ -414,10 +450,14 @@ void MIDISound(int Channel,int Freq,int Volume)
   if(!Volume||!Freq) NoteOff(Channel);
   else
   {
-    /* SND_TRIANGLE is twice quieter than SND_MELODIC */
-    if(MidiCH[Channel].Type==SND_TRIANGLE) Volume=(Volume+1)/2;
+    /* SND_TRIANGLE has 1/2 volume of SND_MELODIC   */
+    /* SND_WAVE may have different effective volume */
+    Volume = MidiCH[Channel].Type==SND_TRIANGLE? (Volume>>1)
+           : MidiCH[Channel].Type==SND_WAVE?     ((Volume*MidiCH[Channel].Power)>>8)
+           : Volume;
+
     /* Compute MIDI note parameters */
-    MIDIVolume = (127*Volume+128)/255;
+    MIDIVolume = Volume>>1;
     MIDINote   = Freqs[Freq/3].Note;
     MIDIWheel  = Freqs[Freq/3].Wheel;
 
@@ -471,7 +511,7 @@ void MIDIDrum(int Type,int Force)
   /* Release previous drum */
   if(DrumOn) MIDIMessage(0x89,DrumOn,127);
   /* Hit next drum */
-  if(Type) MIDIMessage(0x99,Type,(Force&0xFF)/2);
+  if(Type) MIDIMessage(0x99,Type,(Force&0xFF)>>1);
   DrumOn=Type;
 }
 
@@ -577,7 +617,6 @@ unsigned int InitSound(unsigned int Rate,unsigned int Latency)
 
   /* Initialize internal variables (keeping MasterVolume/MasterSwitch!) */
   SndRate  = 0;
-  NoiseGen = 1;
 
   /* Reset sound parameters */
   for(I=0;I<SND_CHANNELS;I++)
@@ -618,7 +657,6 @@ void RenderAudio(int *Wave,unsigned int Samples)
 
   /* Keep GCC happy about variable initialization */
   N=L=A2=0;
-
   /* Waveform generator */
   for(J=0;J<SND_CHANNELS;J++)
     if(WaveCH[J].Freq&&(V=WaveCH[J].Volume)&&(MasterSwitch&(1<<J)))
@@ -693,18 +731,27 @@ void RenderAudio(int *Wave,unsigned int Samples)
 
         case SND_NOISE: /* White Noise */
           /* For high frequencies, recompute volume */
-          if(WaveCH[J].Freq<=SndRate) K=0x10000*WaveCH[J].Freq/SndRate;
-          else { V=V*SndRate/WaveCH[J].Freq;K=0x10000; }
+          if(WaveCH[J].Freq<SndRate)
+            K=((unsigned int)WaveCH[J].Freq<<16)/SndRate;
+          else
+          {
+            V = V*SndRate/WaveCH[J].Freq;
+            K = 0x10000;
+          }
           L1=WaveCH[J].Count;
           for(I=0;I<Samples;I++)
           {
+            /* Use NoiseOut bit for output */
+            Wave[I]+=((NoiseGen>>NoiseOut)&1? 127:-128)*V;
             L1+=K;
             if(L1&0xFFFF0000)
             {
-              if((NoiseGen<<=1)&0x80000000) NoiseGen^=0x08000001;
+              /* XOR NoiseOut and NoiseXOR bits and feed them back */
+              NoiseGen=
+                (((NoiseGen>>NoiseOut)^(NoiseGen>>NoiseXor))&1)
+              | ((NoiseGen<<1)&((2<<NoiseOut)-1));
               L1&=0xFFFF;
             }
-            Wave[I]+=(NoiseGen&1? 127:-128)*V;
           }
           WaveCH[J].Count=L1;
           break;
@@ -756,12 +803,12 @@ unsigned int PlayAudio(int *Wave,unsigned int Samples)
   {
     /* Compute number of samples to convert */
     J = sizeof(Buf)/sizeof(sample);
-    J = Samples<=J? Samples:J;
+    J = Samples-K>J? J:Samples-K;
 
     /* Convert samples */
     for(I=0;I<J;++I)
     {
-      D      = ((*Wave++)*MasterVolume)/255;
+      D      = ((*Wave++)*MasterVolume)>>8;
       D      = D>32767? 32767:D<-32768? -32768:D;
 #if defined(BPU16)
       Buf[I] = D+32768;

--- a/EMULib/Sound.h
+++ b/EMULib/Sound.h
@@ -6,7 +6,7 @@
 /** functions needed to log soundtrack into a MIDI file.    **/
 /** See Sound.c and the sound drivers for the code.         **/ 
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Sound.h
+++ b/EMULib/Sound.h
@@ -100,6 +100,13 @@ void SetSound(int Channel,int NewType);
 /*************************************************************/
 void SetChannels(int Volume,int Switch);
 
+/** SetNoise() ***********************************************/
+/** Initialize random noise generator to the given Seed and **/
+/** then take random output from OUTBit and XOR it with     **/
+/** XORBit.                                                 **/
+/*************************************************************/
+void SetNoise(int Seed,int OUTBit,int XORBit);
+
 /** SetWave() ************************************************/
 /** Set waveform for a given channel. The channel will be   **/
 /** marked with sound type SND_WAVE. Set Rate=0 if you want **/

--- a/EMULib/WD1793.c
+++ b/EMULib/WD1793.c
@@ -34,6 +34,7 @@ void Reset1793(WD1793 *D,FDIDisk *Disks,byte Eject)
   D->WRLength = 0;
   D->RDLength = 0;
   D->Wait     = 0;
+  D->Cmd      = 0xD0;
 
   /* For all drives... */
   for(J=0;J<4;++J)
@@ -60,8 +61,16 @@ byte Read1793(WD1793 *D,byte A)
       A=D->R[0];
       /* If no disk present, set F_NOTREADY */
       if(!D->Disk[D->Drive]||!D->Disk[D->Drive]->Data) A|=F_NOTREADY;
+      if(D->Cmd<0x80)
+      {
+        /* Keep flipping F_INDEX bit as the disk rotates (Sam Coupe) */
+        D->R[0]=(D->R[0]^F_INDEX)&(F_INDEX|F_BUSY|F_NOTREADY|F_READONLY|F_TRACK0);
+      }
+      else
+      {
       /* When reading status, clear all bits but F_BUSY and F_NOTREADY */
-      D->R[0]&=F_BUSY|F_NOTREADY;
+        D->R[0]&=F_BUSY|F_NOTREADY|F_READONLY|F_DRQ;
+      }
       return(A);
     case WD1793_TRACK:
     case WD1793_SECTOR:
@@ -125,6 +134,7 @@ byte Write1793(WD1793 *D,byte A,byte V)
       {
         /* Reset any executing command */
         D->RDLength=D->WRLength=0;
+        D->Cmd=0xD0;
         /* Either reset BUSY flag or reset all flags if BUSY=0 */
         if(D->R[0]&F_BUSY) D->R[0]&=~F_BUSY;
         else               D->R[0]=D->Track[D->Drive]? 0:F_TRACK0;
@@ -137,6 +147,7 @@ byte Write1793(WD1793 *D,byte A,byte V)
       if(D->R[0]&F_BUSY) break;
       /* Reset status register */
       D->R[0]=0x00;
+      D->Cmd=V;
       /* Depending on the command... */
       switch(V&0xF0)
       {

--- a/EMULib/WD1793.c
+++ b/EMULib/WD1793.c
@@ -6,7 +6,7 @@
 /** controller produced by Western Digital. See WD1793.h    **/
 /** for declarations.                                       **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2005-2014                 **/
+/** Copyright (C) Marat Fayzullin 2005-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/WD1793.h
+++ b/EMULib/WD1793.h
@@ -90,6 +90,7 @@ typedef struct
   byte LastS;       /* Last STEP direction */
   byte IRQ;         /* 0x80: IRQ pending, 0x40: DRQ pending */
   byte Wait;        /* Expiration counter */
+  byte Cmd;         /* Last command */
 
   int  WRLength;    /* Data left to write */
   int  RDLength;    /* Data left to read */

--- a/EMULib/WD1793.h
+++ b/EMULib/WD1793.h
@@ -6,7 +6,7 @@
 /** controller produced by Western Digital. See WD1793.c    **/
 /** for implementation.                                     **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2005-2014                 **/
+/** Copyright (C) Marat Fayzullin 2005-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/YM2413.c
+++ b/EMULib/YM2413.c
@@ -6,7 +6,7 @@
 /** produced by Yamaha (also see OPL2, OPL3, OPL4 chips).   **/
 /** See YM2413.h for declarations.                          **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/YM2413.h
+++ b/EMULib/YM2413.h
@@ -6,7 +6,7 @@
 /** produced by Yamaha (also see OPL2, OPL3, OPL4 chips).   **/
 /** See YM2413.h for the code.                              **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2014                 **/
+/** Copyright (C) Marat Fayzullin 1996-2016                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/Boot.h
+++ b/fMSX/Boot.h
@@ -5,7 +5,7 @@
 /** This file contains MSX boot sector image used to create **/
 /** new disk images during FORMAT operation.                **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2014                 **/
+/** Copyright (C) Marat Fayzullin 1994-2017                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/Common.h
+++ b/fMSX/Common.h
@@ -7,7 +7,7 @@
 /** implementations. It also includes dummy sound drivers   **/
 /** for fMSX.                                               **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2014                 **/
+/** Copyright (C) Marat Fayzullin 1994-2017                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/Common.h
+++ b/fMSX/Common.h
@@ -103,8 +103,9 @@ pixel *RefreshBorder(byte Y,pixel C)
 /*************************************************************/
 void Sprites(byte Y,pixel *Line)
 {
+  static const byte SprHeights[4] = { 8,16,16,32 };
   pixel *P,C;
-  byte H,*PT,*AT;
+  byte OH,IH,*PT,*AT;
   unsigned int M;
   int L,K;
 
@@ -112,10 +113,11 @@ void Sprites(byte Y,pixel *Line)
   VDPStatus[0]&=~0x5F;
 
   /* Assign initial values before counting */
-  H  = Sprites16x16? 16:8;
+  OH = SprHeights[VDP[1]&0x03];
+  IH = SprHeights[VDP[1]&0x02];
   AT = SprTab-4;
   Y += VScroll;
-  C  = 0;
+  C  = MAXSPRITE1+1;
   M  = 0;
 
   /* Count displayed sprites */
@@ -124,17 +126,16 @@ void Sprites(byte Y,pixel *Line)
     M<<=1;AT+=4;        /* Iterating through SprTab      */
     K=AT[0];            /* K = sprite Y coordinate       */
     if(K==208) break;   /* Iteration terminates if Y=208 */
-    if(K>256-H) K-=256; /* Y coordinate may be negative  */
+    if(K>256-IH) K-=256; /* Y coordinate may be negative  */
 
     /* Mark all valid sprites with 1s, break at MAXSPRITE1 sprites */
-    if((Y>K)&&(Y<=K+H))
+    if((Y>K)&&(Y<=K+OH))
     {
       /* If we exceed the maximum number of sprites per line... */
-      if(++C==MAXSPRITE1+1)
+      if(!--C)
       {
-        /* Record extra sprite number in the VDP status register */
-        VDPStatus[0]|=0x40|(L&0x1F);
-
+        /* Set 5thSprite flag in the VDP status register */
+        VDPStatus[0]|=0x40;
         /* Stop drawing sprites, unless all-sprites option enabled */
         if(!OPTION(MSX_ALLSPRITE)) break;
       }
@@ -144,6 +145,9 @@ void Sprites(byte Y,pixel *Line)
     }
   }
 
+  /* Mark last checked sprite (5th in line, Y=208, or sprite #31) */
+  VDPStatus[0]|=L<32? L:31;
+
   /* Draw all marked sprites */
   for(;M;M>>=1,AT-=4)
     if(M&1)
@@ -152,38 +156,82 @@ void Sprites(byte Y,pixel *Line)
       L=C&0x80? AT[1]-32:AT[1]; /* Sprite may be shifted left by 32 */
       C&=0x0F;                  /* C = sprite color */
 
-      if((L<256)&&(L>-H)&&C)
+      if((L<256)&&(L>-OH)&&C)
       {
         K=AT[0];                /* K = sprite Y coordinate */
-        if(K>256-H) K-=256;     /* Y coordinate may be negative */
+        if(K>256-IH) K-=256;      /* Y coordinate may be negative */
 
         P=Line+L;
-        PT=SprGen+((int)(H>8? AT[2]&0xFC:AT[2])<<3)+Y-K-1;
+        K  = Y-K-1;
+        PT = SprGen+((int)(IH>8? AT[2]&0xFC:AT[2])<<3)+(OH>IH? (K>>1):K);
         C=XPal[C];
 
         /* Mask 1: clip left sprite boundary */
-        K=L>=0? 0x0FFFF:(0x10000>>-L)-1;
-        /* Mask 2: clip right sprite boundary */
-        if(L>256-H) K^=((0x00200>>(H-8))<<(L-257+H))-1;
-        /* Get and clip the sprite data */
-        K&=((int)PT[0]<<8)|(H>8? PT[16]:0x00);
+        K=L>=0? 0xFFFF:(0x10000>>(OH>IH? (-L>>1):-L))-1;
 
-        /* Draw left 8 pixels of the sprite */
-        if(K&0xFF00)
+        /* Mask 2: clip right sprite boundary */
+        L+=(int)OH-257;
+        if(L>=0)
         {
-          if(K&0x8000) P[0]=C;if(K&0x4000) P[1]=C;
-          if(K&0x2000) P[2]=C;if(K&0x1000) P[3]=C;
-          if(K&0x0800) P[4]=C;if(K&0x0400) P[5]=C;
-          if(K&0x0200) P[6]=C;if(K&0x0100) P[7]=C;
+          L=(IH>8? 0x0002:0x0200)<<(OH>IH? (L>>1):L);
+          K&=~(L-1);
         }
 
-        /* Draw right 8 pixels of the sprite */
-        if(K&0x00FF)
+        /* Get and clip the sprite data */
+        K&=((int)PT[0]<<8)|(IH>8? PT[16]:0x00);
+
+        /* If output size is bigger than the input size... */
+        if(OH>IH)
         {
-          if(K&0x0080) P[8]=C; if(K&0x0040) P[9]=C;
-          if(K&0x0020) P[10]=C;if(K&0x0010) P[11]=C;
-          if(K&0x0008) P[12]=C;if(K&0x0004) P[13]=C;
-          if(K&0x0002) P[14]=C;if(K&0x0001) P[15]=C;
+          /* Big (zoomed) sprite */
+
+          /* Draw left 16 pixels of the sprite */
+          if(K&0xFF00)
+          {
+            if(K&0x8000) P[1]=P[0]=C;
+            if(K&0x4000) P[3]=P[2]=C;
+            if(K&0x2000) P[5]=P[4]=C;
+            if(K&0x1000) P[7]=P[6]=C;
+            if(K&0x0800) P[9]=P[8]=C;
+            if(K&0x0400) P[11]=P[10]=C;
+            if(K&0x0200) P[13]=P[12]=C;
+            if(K&0x0100) P[15]=P[14]=C;
+          }
+
+          /* Draw right 16 pixels of the sprite */
+          if(K&0x00FF)
+          {
+            if(K&0x0080) P[17]=P[16]=C;
+            if(K&0x0040) P[19]=P[18]=C;
+            if(K&0x0020) P[21]=P[20]=C;
+            if(K&0x0010) P[23]=P[22]=C;
+            if(K&0x0008) P[25]=P[24]=C;
+            if(K&0x0004) P[27]=P[26]=C;
+            if(K&0x0002) P[29]=P[28]=C;
+            if(K&0x0001) P[31]=P[30]=C;
+          }
+        }
+        else
+        {
+          /* Normal (unzoomed) sprite */
+
+          /* Draw left 8 pixels of the sprite */
+          if(K&0xFF00)
+          {
+            if(K&0x8000) P[0]=C;if(K&0x4000) P[1]=C;
+            if(K&0x2000) P[2]=C;if(K&0x1000) P[3]=C;
+            if(K&0x0800) P[4]=C;if(K&0x0400) P[5]=C;
+            if(K&0x0200) P[6]=C;if(K&0x0100) P[7]=C;
+          }
+
+          /* Draw right 8 pixels of the sprite */
+          if(K&0x00FF)
+          {
+            if(K&0x0080) P[8]=C; if(K&0x0040) P[9]=C;
+            if(K&0x0020) P[10]=C;if(K&0x0010) P[11]=C;
+            if(K&0x0008) P[12]=C;if(K&0x0004) P[13]=C;
+            if(K&0x0002) P[14]=C;if(K&0x0001) P[15]=C;
+          }
         }
       }
     }
@@ -192,11 +240,12 @@ void Sprites(byte Y,pixel *Line)
 /** ColorSprites() *******************************************/
 /** This function is called from RefreshLine#() to refresh  **/
 /** color sprites in SCREENs 4-8. The result is returned in **/
-/** ZBuf, whose size must be 304 bytes (32+256+16).         **/
+/** ZBuf, whose size must be 320 bytes (32+256+32).         **/
 /*************************************************************/
 void ColorSprites(byte Y,byte *ZBuf)
 {
-  byte C,H,J,OrThem;
+  static const byte SprHeights[4] = { 8,16,16,32 };
+  byte C,IH,OH,J,OrThem;
   byte *P,*PT,*AT;
   int L,K;
   unsigned int M;
@@ -210,9 +259,10 @@ void ColorSprites(byte Y,byte *ZBuf)
 
   /* Assign initial values before counting */
   OrThem = 0x00;
-  H  = Sprites16x16? 16:8;
+  OH = SprHeights[VDP[1]&0x03];
+  IH = SprHeights[VDP[1]&0x02];
   AT = SprTab-4;
-  C  = 0;
+  C  = MAXSPRITE2+1;
   M  = 0;
 
   /* Count displayed sprites */
@@ -222,17 +272,16 @@ void ColorSprites(byte Y,byte *ZBuf)
     K=AT[0];                  /* Read Y from SprTab            */
     if(K==216) break;         /* Iteration terminates if Y=216 */
     K=(byte)(K-VScroll);      /* Sprite's actual Y coordinate  */
-    if(K>256-H) K-=256;       /* Y coordinate may be negative  */
+    if(K>256-IH) K-=256;       /* Y coordinate may be negative  */
 
     /* Mark all valid sprites with 1s, break at MAXSPRITE2 sprites */
-    if((Y>K)&&(Y<=K+H))
+    if((Y>K)&&(Y<=K+OH))
     {
       /* If we exceed the maximum number of sprites per line... */
-      if(++C==MAXSPRITE2+1)
+      if(!--C)
       {
-        /* Record extra sprite number in the VDP status register */
-        VDPStatus[0]|=0x40|(L&0x1F);
-
+        /* Set 9thSprite flag in the VDP status register */
+        VDPStatus[0]|=0x40;
         /* Stop drawing sprites, unless all-sprites option enabled */
         if(!OPTION(MSX_ALLSPRITE)) break;
       }
@@ -242,52 +291,100 @@ void ColorSprites(byte Y,byte *ZBuf)
     }
   }
 
+  /* Mark last checked sprite (9th in line, Y=216, or sprite #31) */
+  VDPStatus[0]|=L<32? L:31;
+
   /* Draw all marked sprites */
   for(;M;M>>=1,AT-=4)
     if(M&1)
     {
       K=(byte)(AT[0]-VScroll); /* K = sprite Y coordinate */
-      if(K>256-H) K-=256;      /* Y coordinate may be negative */
+      if(K>256-IH) K-=256;        /* Y coordinate may be negative */
 
       J=Y-K-1;
+      J = OH>IH? (J>>1):J;
       C=SprTab[-0x0200+((AT-SprTab)<<2)+J];
       OrThem|=C&0x40;
 
       if(C&0x0F)
       {
-        PT=SprGen+((int)(H>8? AT[2]&0xFC:AT[2])<<3)+J;
+        PT = SprGen+((int)(IH>8? AT[2]&0xFC:AT[2])<<3)+J;
         P=ZBuf+AT[1]+(C&0x80? 0:32);
         C&=0x0F;
         J=PT[0];
 
         if(OrThem&0x20)
         {
-          if(J&0x80) P[0]|=C;if(J&0x40) P[1]|=C;
-          if(J&0x20) P[2]|=C;if(J&0x10) P[3]|=C;
-          if(J&0x08) P[4]|=C;if(J&0x04) P[5]|=C;
-          if(J&0x02) P[6]|=C;if(J&0x01) P[7]|=C;
-          if(H>8)
+          if(OH>IH)
           {
-            J=PT[16];
-            if(J&0x80) P[8]|=C; if(J&0x40) P[9]|=C;
-            if(J&0x20) P[10]|=C;if(J&0x10) P[11]|=C;
-            if(J&0x08) P[12]|=C;if(J&0x04) P[13]|=C;
-            if(J&0x02) P[14]|=C;if(J&0x01) P[15]|=C;
+            if(J&0x80) { P[0]|=C;P[1]|=C; }
+            if(J&0x40) { P[2]|=C;P[3]|=C; }
+            if(J&0x20) { P[4]|=C;P[5]|=C; }
+            if(J&0x10) { P[6]|=C;P[7]|=C; }
+            if(J&0x08) { P[8]|=C;P[9]|=C; }
+            if(J&0x04) { P[10]|=C;P[11]|=C; }
+            if(J&0x02) { P[12]|=C;P[13]|=C; }
+            if(J&0x01) { P[14]|=C;P[15]|=C; }
+            if(IH>8)
+            {
+              J=PT[16];
+              if(J&0x80) { P[16]|=C;P[17]|=C; }
+              if(J&0x40) { P[18]|=C;P[19]|=C; }
+              if(J&0x20) { P[20]|=C;P[21]|=C; }
+              if(J&0x10) { P[22]|=C;P[23]|=C; }
+              if(J&0x08) { P[24]|=C;P[25]|=C; }
+              if(J&0x04) { P[26]|=C;P[27]|=C; }
+              if(J&0x02) { P[28]|=C;P[29]|=C; }
+              if(J&0x01) { P[30]|=C;P[31]|=C; }
+            }
+          }
+          else
+          {
+            if(J&0x80) P[0]|=C;if(J&0x40) P[1]|=C;
+            if(J&0x20) P[2]|=C;if(J&0x10) P[3]|=C;
+            if(J&0x08) P[4]|=C;if(J&0x04) P[5]|=C;
+            if(J&0x02) P[6]|=C;if(J&0x01) P[7]|=C;
+            if(IH>8)
+            {
+              J=PT[16];
+              if(J&0x80) P[8]|=C; if(J&0x40) P[9]|=C;
+              if(J&0x20) P[10]|=C;if(J&0x10) P[11]|=C;
+              if(J&0x08) P[12]|=C;if(J&0x04) P[13]|=C;
+              if(J&0x02) P[14]|=C;if(J&0x01) P[15]|=C;
+            }
           }
         }
         else
         {
-          if(J&0x80) P[0]=C;if(J&0x40) P[1]=C;
-          if(J&0x20) P[2]=C;if(J&0x10) P[3]=C;
-          if(J&0x08) P[4]=C;if(J&0x04) P[5]=C;
-          if(J&0x02) P[6]=C;if(J&0x01) P[7]=C;
-          if(H>8)
+          if(OH>IH)
           {
-            J=PT[16];
-            if(J&0x80) P[8]=C; if(J&0x40) P[9]=C;
-            if(J&0x20) P[10]=C;if(J&0x10) P[11]=C;
-            if(J&0x08) P[12]=C;if(J&0x04) P[13]=C;
-            if(J&0x02) P[14]=C;if(J&0x01) P[15]=C;
+            if(J&0x80) P[0]=P[1]=C;  if(J&0x40) P[2]=P[3]=C;
+            if(J&0x20) P[4]=P[5]=C;  if(J&0x10) P[6]=P[7]=C;
+            if(J&0x08) P[8]=P[9]=C;  if(J&0x04) P[10]=P[11]=C;
+            if(J&0x02) P[12]=P[13]=C;if(J&0x01) P[14]=P[15]=C;
+            if(IH>8)
+            {
+              J=PT[16];
+              if(J&0x80) P[16]=P[17]=C;if(J&0x40) P[18]=P[19]=C;
+              if(J&0x20) P[20]=P[21]=C;if(J&0x10) P[22]=P[23]=C;
+              if(J&0x08) P[24]=P[25]=C;if(J&0x04) P[26]=P[27]=C;
+              if(J&0x02) P[28]=P[29]=C;if(J&0x01) P[30]=P[31]=C;
+            }
+          }
+          else
+          {
+            if(J&0x80) P[0]=C;if(J&0x40) P[1]=C;
+            if(J&0x20) P[2]=C;if(J&0x10) P[3]=C;
+            if(J&0x08) P[4]=C;if(J&0x04) P[5]=C;
+            if(J&0x02) P[6]=C;if(J&0x01) P[7]=C;
+            if(IH>8)
+            {
+              J=PT[16];
+              if(J&0x80) P[8]=C; if(J&0x40) P[9]=C;
+              if(J&0x20) P[10]=C;if(J&0x10) P[11]=C;
+              if(J&0x08) P[12]=C;if(J&0x04) P[13]=C;
+              if(J&0x02) P[14]=C;if(J&0x01) P[15]=C;
+            }
           }
         }
       }
@@ -451,7 +548,7 @@ void RefreshLine4(byte Y)
   pixel *P,FC,BC;
   byte K,X,C,*T,*R;
   int I,J;
-  byte ZBuf[304];
+  byte ZBuf[320];
 
   P=RefreshBorder(Y,XPal[BGColor]);
   if(!P) return;
@@ -493,7 +590,7 @@ void RefreshLine5(byte Y)
 {
   pixel *P;
   byte I,X,*T,*R;
-  byte ZBuf[304];
+  byte ZBuf[320];
 
   P=RefreshBorder(Y,XPal[BGColor]);
   if(!P) return;
@@ -540,7 +637,7 @@ void RefreshLine8(byte Y)
   };
   pixel *P;
   byte C,X,*T,*R;
-  byte ZBuf[304];
+  byte ZBuf[320];
 
   P=RefreshBorder(Y,BPal[VDP[7]]);
   if(!P) return;
@@ -575,7 +672,7 @@ void RefreshLine10(byte Y)
   pixel *P;
   byte C,X,*T,*R;
   int J,K;
-  byte ZBuf[304];
+  byte ZBuf[320];
 
   P=RefreshBorder(Y,BPal[VDP[7]]);
   if(!P) return;
@@ -618,7 +715,7 @@ void RefreshLine12(byte Y)
   pixel *P;
   byte C,X,*T,*R;
   int J,K;
-  byte ZBuf[304];
+  byte ZBuf[320];
 
   P=RefreshBorder(Y,BPal[VDP[7]]);
   if(!P) return;
@@ -665,7 +762,7 @@ void RefreshLine6(byte Y)
 {
   pixel *P;
   byte X,*T,*R,C;
-  byte ZBuf[304];
+  byte ZBuf[320];
 
   P=RefreshBorder(Y,XPal[BGColor&0x03]);
   if(!P) return;
@@ -700,7 +797,7 @@ void RefreshLine7(byte Y)
 {
   pixel *P;
   byte C,X,*T,*R;
-  byte ZBuf[304];
+  byte ZBuf[320];
 
   P=RefreshBorder(Y,XPal[BGColor]);
   if(!P) return;

--- a/fMSX/CommonMux.h
+++ b/fMSX/CommonMux.h
@@ -6,7 +6,7 @@
 /** possible screen depth. It includes common driver code   **/
 /** from Common.h and Wide.h.                               **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2014                 **/
+/** Copyright (C) Marat Fayzullin 1994-2017                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/I8251.c
+++ b/fMSX/I8251.c
@@ -6,7 +6,7 @@
 /** chip and the 8253 timer chip implementing a generic     **/
 /** RS232 interface.                                        **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2004-2014                 **/
+/** Copyright (C) Marat Fayzullin 2004-2017                 **/
 /**               Maarten ter Huurne 2000                   **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/

--- a/fMSX/I8251.h
+++ b/fMSX/I8251.h
@@ -5,7 +5,7 @@
 /** This file contains definitions and declarations for     **/
 /** routines in I8251.c.                                    **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2004-2014                 **/
+/** Copyright (C) Marat Fayzullin 2004-2017                 **/
 /**               Maarten ter Huurne 2000                   **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/

--- a/fMSX/MSX.c
+++ b/fMSX/MSX.c
@@ -7,7 +7,7 @@
 /** etc. Initialization code and definitions needed for the **/
 /** machine-dependent drivers are also here.                **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2014                 **/
+/** Copyright (C) Marat Fayzullin 1994-2017                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/MSX.c
+++ b/fMSX/MSX.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <fcntl.h>
+#include <unistd.h>
 #include <time.h>
 
 #ifdef _WIN32
@@ -51,7 +51,7 @@
 #endif
 
 /** User-defined parameters for fMSX *************************/
-int  Mode        = MSX_MSX2|MSX_NTSC|MSX_GUESSA|MSX_GUESSB;
+int  Mode        = MSX_MSX2|MSX_NTSC|MSX_MSXDOS2|MSX_GUESSA|MSX_GUESSB;
 byte Verbose     = 1;              /* Debug msgs ON/OFF      */
 byte UPeriod     = 75;             /* % of frames to draw    */
 int  VPeriod     = CPU_VPERIOD;    /* CPU cycles per VBlank  */
@@ -84,7 +84,7 @@ byte PSL[4],SSL[4];                /* Lists of current slots */
 byte PSLReg,SSLReg[4];   /* Storage for A8h port and (FFFFh) */
 
 /** Memory blocks to free in TrashMSX() **********************/
-const byte *Chunks[MAXCHUNKS];     /* Memory blocks to free  */
+void *Chunks[MAXCHUNKS];           /* Memory blocks to free  */
 int NChunks;                       /* Number of memory blcks */
 
 /** Working directory names **********************************/
@@ -163,7 +163,7 @@ byte *SprGen,*SprTab;              /* VDP tables (sprites)   */
 int  ChrGenM,ChrTabM,ColTabM;      /* VDP masks (screen)     */
 int  SprTabM;                      /* VDP masks (sprites)    */
 word VAddr;                        /* VRAM address in VDP    */
-byte VKey,PKey,WKey;               /* Status keys for VDP    */
+byte VKey,PKey;                    /* Status keys for VDP    */
 byte FGColor,BGColor;              /* Colors                 */
 byte XFGColor,XBGColor;            /* Second set of colors   */
 byte ScrMode;                      /* Current screen mode    */
@@ -287,7 +287,7 @@ void SSlot(byte V);               /* Switch secondary slots          */
 void VDPOut(byte R,byte V);       /* Write value into a VDP register */
 void Printer(byte V);             /* Send a character to a printer   */
 void PPIOut(byte New,byte Old);   /* Set PPI bits (key click, etc.)  */
-void CheckSprites(void);          /* Check collisions and 5th sprite */
+int  CheckSprites(void);          /* Check for sprite collisions     */
 byte RTCIn(byte R);               /* Read RTC registers              */
 byte SetScreen(void);             /* Change screen mode              */
 word SetIRQ(byte IRQ);            /* Set/Reset IRQ                   */
@@ -295,7 +295,7 @@ word StateID(void);               /* Compute emulation state ID      */
 
 static int hasext(const char *FileName,const char *Ext);
 static byte *GetMemory(int Size); /* Get memory chunk                */
-static void FreeMemory(byte *Ptr);/* Free memory chunk               */
+static void FreeMemory(const void *Ptr); /* Free memory chunk        */
 static void FreeAllMemory(void);  /* Free all memory chunks          */
 
 /* Forward declarations */
@@ -353,18 +353,18 @@ static byte *GetMemory(int Size)
 /** FreeMemory() *********************************************/
 /** Free memory allocated by a previous GetMemory() call.   **/
 /*************************************************************/
-static void FreeMemory(byte *Ptr)
+static void FreeMemory(const void *Ptr)
 {
   int J;
 
   /* Special case: we do not free EmptyRAM! */
-  if(!Ptr||(Ptr==EmptyRAM)) return;
+  if(!Ptr||(Ptr==(void *)EmptyRAM)) return;
 
   for(J=0;(J<NChunks)&&(Ptr!=Chunks[J]);++J);
   if(J<NChunks)
   {
+    free(Chunks[J]);
     for(--NChunks;J<NChunks;++J) Chunks[J]=Chunks[J+1];
-    free(Ptr);
   }
 }
 
@@ -375,7 +375,7 @@ static void FreeAllMemory(void)
 {
   int J;
 
-  for(J=0;J<NChunks;++J) free((void *)Chunks[J]);
+  for(J=0;J<NChunks;++J) free(Chunks[J]);
   NChunks=0;
 }
 
@@ -458,8 +458,7 @@ int StartMSX(int NewMode,int NewRAMPages,int NewVRAMPages)
         MemMap[I][J][K]=EmptyRAM;
 
   /* Save current directory */
-  if(ProgDir)
-    if((WorkDir = getcwd(cwd, sizeof(cwd)))) Chunks[NChunks++]=WorkDir;
+  if((ProgDir&&(WorkDir = getcwd(cwd, sizeof(cwd))))) Chunks[NChunks++]=(void *)WorkDir;
     
   /* Set invalid modes and RAM/VRAM sizes before calling ResetMSX() */
   Mode      = ~NewMode;
@@ -497,7 +496,7 @@ int StartMSX(int NewMode,int NewRAMPages,int NewVRAMPages)
 
   /* If MSX2 or better and DiskROM present...  */
   /* ...try loading MSXDOS2 cartridge into 3:0 */
-  if(!MODEL(MSX_MSX1)&&(MemMap[3][1][2]!=EmptyRAM)&&!ROMData[2])
+  if(!MODEL(MSX_MSX1)&&OPTION(MSX_MSXDOS2)&&(MemMap[3][1][2]!=EmptyRAM)&&!ROMData[2])
     if(LoadCart("MSXDOS2.ROM",2,MAP_GEN16))
       SetMegaROM(2,0,1,ROMMask[J]-1,ROMMask[J]);
 
@@ -906,7 +905,7 @@ int ResetMSX(int NewMode,int NewRAMPages,int NewVRAMPages)
   VPAGE=VRAM;                           /* VRAM page        */
   FGColor=BGColor=XFGColor=XBGColor=0;  /* VDP colors       */
   ScrMode=0;                            /* Screen mode      */
-  VKey=PKey=1;WKey=0;                   /* VDP keys         */
+  VKey=PKey=1;                          /* VDP keys         */
   VAddr=0x0000;                         /* VRAM access addr */
   ScanLine=0;                           /* Current scanline */
   VDPData=NORAM;                        /* VDP data buffer  */
@@ -1193,19 +1192,8 @@ case 0x87:
 
 case 0x98: /* VDP Data */
   VKey=1;
-  if(WKey)
-  {
-    /* VDP set for writing */
-    VDPData=VPAGE[VAddr]=Value;
-    VAddr=(VAddr+1)&0x3FFF;
-  }
-  else
-  {
-    /* VDP set for reading */
-    VDPData=VPAGE[VAddr];
-    VAddr=(VAddr+1)&0x3FFF;
-    VPAGE[VAddr]=Value;
-  }
+  VDPData=VPAGE[VAddr]=Value;
+  VAddr=(VAddr+1)&0x3FFF;
   /* If VAddr rolled over, modify VRAM page# */
   if(!VAddr&&(ScrMode>3))
   {
@@ -1229,10 +1217,8 @@ case 0x99: /* VDP Address Latch */
       case 0x40:
         /* Set the VRAM access address */
         VAddr=(((word)Value<<8)+ALatch)&0x3FFF;
-        /* WKey=1 when VDP set for writing into VRAM */
-        WKey=Value&0x40;
         /* When set for reading, perform first read */
-        if(!WKey)
+        if(!(Value&0x40))
         {
           VDPData=VPAGE[VAddr];
           VAddr=(VAddr+1)&0x3FFF;
@@ -1381,35 +1367,35 @@ void MapROM(word A,byte V)
   /* SCC: enable/disable for no cart */
   if(!ROMData[I]&&(A==0x9000)) SCCOn[I]=(V==0x3F)? 1:0;
 
-  /* SCC: types 0, 2, or no cart */
-  if(((A&0xFF00)==0x9800)&&SCCOn[I])
+  /* If writing to SCC... */
+  if(SCCOn[I]&&((A&0xDF00)==0x9800))
   {
     /* Compute SCC register number */
     J=A&0x00FF;
 
+    /* If using SCC+... */
+    if(A&0x2000)
+    {
     /* When no MegaROM present, we allow the program */
     /* to write into SCC wave buffer using EmptyRAM  */
     /* as a scratch pad.                             */
-    if(!ROMData[I]&&(J<0x80)) EmptyRAM[0x1800+J]=V;
+      if(!ROMData[I]&&(J<0xA0)) EmptyRAM[0x1800+J]=V;
 
     /* Output data to SCC chip */
-    WriteSCC(&SCChip,J,V);
-    return;
+      WriteSCCP(&SCChip,J,V);
   }
-
-  /* SCC+: types 0, 2, or no cart */
-  if(((A&0xFF00)==0xB800)&&SCCOn[I])
+    else
   {
-    /* Compute SCC register number */
-    J=A&0x00FF;
-
     /* When no MegaROM present, we allow the program */
     /* to write into SCC wave buffer using EmptyRAM  */
     /* as a scratch pad.                             */
-    if(!ROMData[I]&&(J<0xA0)) EmptyRAM[0x1800+J]=V;
+      if(!ROMData[I]&&(J<0x80)) EmptyRAM[0x1800+J]=V;
 
     /* Output data to SCC chip */
-    WriteSCCP(&SCChip,J,V);
+      WriteSCC(&SCChip,J,V);
+    }
+
+    /* Done writing to SCC */   
     return;
   }
 
@@ -1444,6 +1430,7 @@ void MapROM(word A,byte V)
         RAM[J+2]=MemMap[PS][SS][J+2]=ROMData[I]+((int)V<<13);
         RAM[J+3]=MemMap[PS][SS][J+3]=RAM[J+2]+0x2000;
         ROMMapper[I][J]=V;
+        ROMMapper[I][J+1]=V|1;
       }
       return;
 
@@ -1516,8 +1503,11 @@ void MapROM(word A,byte V)
       break;
 
     case MAP_ASCII16: /*** ASCII 16kB cartridges ***/
+      /* NOTE: Vauxall writes garbage to to 7xxxh */
+      /* NOTE: Darwin writes valid data to 6x00h (ASCII8 mapper) */
+      /* NOTE: Androgynus writes valid data to 77FFh */
       /* If switching pages... */
-      if((A>=0x6000)&&(A<0x8000))
+      if((A>=0x6000)&&(A<0x8000)&&((V<=ROMMask[I]+1)||!(A&0x0FFF)))
       {
         J=(A&0x1000)>>11;
         /* If selecting SRAM... */
@@ -1539,6 +1529,7 @@ void MapROM(word A,byte V)
           MemMap[PS][SS][J+2]=P;
           MemMap[PS][SS][J+3]=P+0x2000;
           ROMMapper[I][J]=V;
+          ROMMapper[I][J+1]=V|1;
           /* Only update memory when cartridge's slot selected */
           if((PSL[(J>>1)+1]==PS)&&(SSL[(J>>1)+1]==SS))
           {
@@ -1608,6 +1599,7 @@ void MapROM(word A,byte V)
         case 0x7FF7: /* ROM page select */
           V=(V<<1)&ROMMask[I];
           ROMMapper[I][0]=V;
+          ROMMapper[I][1]=V|1;
           /* 4000h-5FFFh contains SRAM when correct FMPACKey supplied */
           if(FMPACKey!=FMPAC_MAGIC)
           {
@@ -2055,8 +2047,11 @@ word LoopZ80(Z80 *R)
   /* This way, it can't be shut off by overscan tricks (Maarten) */
   if(ScanLine==192)
   {
-    /* Check sprites and set Collision, 5Sprites, 5thSprite bits */
-    if(!SpritesOFF&&ScrMode&&(ScrMode<MAXSCREEN+1)) CheckSprites();
+    /* Clear 5thSprite fields (wrong place to do it?) */
+    VDPStatus[0]=(VDPStatus[0]&~0x40)|0x1F;
+
+    /* Check sprites and set Collision bit */
+    if(!(VDPStatus[0]&0x20)&&CheckSprites()) VDPStatus[0]|=0x20;
 
     /* Count MIDI ticks and update AY8910 state */
     J=1000*VPeriod/CPU_CLOCK;
@@ -2134,27 +2129,31 @@ word LoopZ80(Z80 *R)
 }
 
 /** CheckSprites() *******************************************/
-/** Check for sprite collisions and 5th/9th sprite in a     **/
-/** row.                                                    **/
+/** Check for sprite collisions.                            **/
 /*************************************************************/
-void CheckSprites(void)
+int CheckSprites(void)
 {
-  word LS,LD;
-  byte DH,DV,*PS,*PD,*T;
-  byte I,J,N,M,*S,*D;
+  unsigned int I,J,LS,LD;
+  byte DH,DV,*S,*D,*PS,*PD,*T;
 
-  /* Clear 5Sprites, Collision, and 5thSprite bits */
-  VDPStatus[0]=(VDPStatus[0]&0x9F)|0x1F;
+  /* Must be showing sprites */
+  if(SpritesOFF||!ScrMode||(ScrMode>=MAXSCREEN+1)) return(0);
 
-  for(N=0,S=SprTab;(N<32)&&(S[0]!=208);N++,S+=4);
-  M=SolidColor0;
+  /* Find bottom/top scanlines */
+  DH = ScrMode>3? 216:208;
+  LD = 255-(Sprites16x16? 16:8);
+  LS = ScanLines212? 211:191;
+
+  /* Find valid, displayed sprites */
+  for(I=J=0,S=SprTab;(I<32)&&(S[0]!=DH);++I,S+=4)
+    if((S[0]<LS)||(S[0]>LD)) J|=1<<I;
 
   if(Sprites16x16)
   {
-    for(J=0,S=SprTab;J<N;++J,S+=4)
-      if((S[3]&0x0F)||M)
-        for(I=J+1,D=S+4;I<N;++I,D+=4)
-          if((D[3]&0x0F)||M)
+    for(S=SprTab;J;J>>=1,S+=4)
+      if(J&1)
+        for(I=J>>1,D=S+4;I;I>>=1,D+=4)
+          if(I&1)
           {
             DV=S[0]-D[0];
             if((DV<16)||(DV>240))
@@ -2168,22 +2167,22 @@ void CheckSprites(void)
                 if(DH>240) { DH=256-DH;T=PS;PS=PD;PD=T; }
                 while(DV<16)
                 {
-                  LS=((word)*PS<<8)+*(PS+16);
-                  LD=((word)*PD<<8)+*(PD+16);
+                  LS=((unsigned int)*PS<<8)+*(PS+16);
+                  LD=((unsigned int)*PD<<8)+*(PD+16);
                   if(LD&(LS>>DH)) break;
-                  else { DV++;PS++;PD++; }
+                  else { ++DV;++PS;++PD; }
                 }
-                if(DV<16) { VDPStatus[0]|=0x20;return; }
+                if(DV<16) return(1);
               }
             }
           }
   }
   else
   {
-    for(J=0,S=SprTab;J<N;++J,S+=4)
-      if((S[3]&0x0F)||M)
-        for(I=J+1,D=S+4;I<N;++I,D+=4)
-          if((D[3]&0x0F)||M)
+    for(S=SprTab;J;J>>=1,S+=4)
+      if(J&1)
+        for(I=J>>1,D=S+4;I;I>>=1,D+=4)
+          if(I&1) 
           {
             DV=S[0]-D[0];
             if((DV<8)||(DV>248))
@@ -2195,12 +2194,15 @@ void CheckSprites(void)
                 PD=SprGen+((int)D[2]<<3);
                 if(DV<8) PD+=DV; else { DV=256-DV;PS+=DV; }
                 if(DH>248) { DH=256-DH;T=PS;PS=PD;PD=T; }
-                while((DV<8)&&!(*PD&(*PS>>DH))) { DV++;PS++;PD++; }
-                if(DV<8) { VDPStatus[0]|=0x20;return; }
+                while((DV<8)&&!(*PD&(*PS>>DH))) { ++DV;++PS;++PD; }
+                if(DV<8) return(1);
               }
             }
           }
   }
+
+  /* No collisions */
+  return(0);
 }
 
 /** StateID() ************************************************/
@@ -2339,10 +2341,12 @@ int LoadFile(const char *FileName)
   if(hasext(FileName,".ROM")||hasext(FileName,".MX1")||hasext(FileName,".MX2"))
     return(!!LoadCart(FileName,0,ROMGUESS(0)|ROMTYPE(0)));
 
-  /* Try loading as a font */
-  if(hasext(FileName,".FNT")) return(!!LoadFNT(FileName));
   /* Try loading as a tape */
   if(hasext(FileName,".CAS")) return(!!ChangeTape(FileName));
+  /* Try loading as a font */
+  if(hasext(FileName,".FNT")) return(!!LoadFNT(FileName));
+  /* Try loading as palette */
+  if(hasext(FileName,".PAL")) return(!!LoadPAL(FileName));
 
   /* Unknown file type */
   return(0);
@@ -2532,8 +2536,9 @@ byte *LoadROM(const char *Name,int Size,byte *Buf)
 int LoadCart(const char *FileName,int Slot,int Type)
 {
   int64_t Len;
-  int C1, C2, Pages, ROM64;
+  int C1, C2, Pages, ROM64, BASIC;
   byte *P,PS,SS;
+  char *T;
   RFILE *F;
 
   /* Slot number must be valid */
@@ -2668,75 +2673,85 @@ int LoadCart(const char *FileName,int Slot,int Type)
   /* Assign ROMMask for MegaROMs */
   ROMMask[Slot]=!ROM64&&(Len>4)? (Pages-1):0x00;
   /* Allocate space for the ROM */
-  ROMData[Slot]=GetMemory(Pages<<13);
-  if(!ROMData[Slot])
+  ROMData[Slot]=P=GetMemory(Pages<<13);
+  if(!P)
      return 0;
 
   /* Try loading ROM */
-  if(!LoadROM(FileName,Len<<13,ROMData[Slot]))
+  if(!LoadROM(FileName,Len<<13,P))
      return 0;
 
   /* Mirror ROM if it is smaller than 2^n pages */
   if(Len<Pages)
-    memcpy
-    (
-      ROMData[Slot]+Len*0x2000,
-      ROMData[Slot]+(Len-Pages/2)*0x2000,
-      (Pages-Len)*0x2000
-    );
+    memcpy(P+Len*0x2000,P+(Len-Pages/2)*0x2000,(Pages-Len)*0x2000); 
+
+  /* Detect ROMs containing BASIC code */
+  BASIC=(P[0]=='A')&&(P[1]=='B')&&!(P[2]||P[3])&&(P[8]||P[9]);
 
   /* Set memory map depending on the ROM size */
   switch(Len)
   {
     case 1:
       /* 8kB ROMs are mirrored 8 times: 0:0:0:0:0:0:0:0 */
-      MemMap[PS][SS][0]=ROMData[Slot];
-      MemMap[PS][SS][1]=ROMData[Slot];
-      MemMap[PS][SS][2]=ROMData[Slot];
-      MemMap[PS][SS][3]=ROMData[Slot];
-      MemMap[PS][SS][4]=ROMData[Slot];
-      MemMap[PS][SS][5]=ROMData[Slot];
-      MemMap[PS][SS][6]=ROMData[Slot];
-      MemMap[PS][SS][7]=ROMData[Slot];
+      if(!BASIC)
+      {
+        MemMap[PS][SS][0]=P;
+        MemMap[PS][SS][1]=P;
+        MemMap[PS][SS][2]=P;
+        MemMap[PS][SS][3]=P;
+      }
+      MemMap[PS][SS][4]=P;
+      MemMap[PS][SS][5]=P;
+      if(!BASIC)
+      {
+        MemMap[PS][SS][6]=P;
+        MemMap[PS][SS][7]=P;
+      }
       break;
 
     case 2:
       /* 16kB ROMs are mirrored 4 times: 0:1:0:1:0:1:0:1 */
-      MemMap[PS][SS][0]=ROMData[Slot];
-      MemMap[PS][SS][1]=ROMData[Slot]+0x2000;
-      MemMap[PS][SS][2]=ROMData[Slot];
-      MemMap[PS][SS][3]=ROMData[Slot]+0x2000;
-      MemMap[PS][SS][4]=ROMData[Slot];
-      MemMap[PS][SS][5]=ROMData[Slot]+0x2000;
-      MemMap[PS][SS][6]=ROMData[Slot];
-      MemMap[PS][SS][7]=ROMData[Slot]+0x2000;
+      if(!BASIC)
+      {
+        MemMap[PS][SS][0]=P;
+        MemMap[PS][SS][1]=P+0x2000;
+        MemMap[PS][SS][2]=P;
+        MemMap[PS][SS][3]=P+0x2000;
+      }
+      MemMap[PS][SS][4]=P;
+      MemMap[PS][SS][5]=P+0x2000;
+      if(!BASIC)
+      {
+        MemMap[PS][SS][6]=P;
+        MemMap[PS][SS][7]=P+0x2000;
+      }
       break;
 
     case 3:
     case 4:
       /* 24kB and 32kB ROMs are mirrored twice: 0:1:0:1:2:3:2:3 */
-      MemMap[PS][SS][0]=ROMData[Slot];
-      MemMap[PS][SS][1]=ROMData[Slot]+0x2000;
-      MemMap[PS][SS][2]=ROMData[Slot];
-      MemMap[PS][SS][3]=ROMData[Slot]+0x2000;
-      MemMap[PS][SS][4]=ROMData[Slot]+0x4000;
-      MemMap[PS][SS][5]=ROMData[Slot]+0x6000;
-      MemMap[PS][SS][6]=ROMData[Slot]+0x4000;
-      MemMap[PS][SS][7]=ROMData[Slot]+0x6000;
+      MemMap[PS][SS][0]=P;
+      MemMap[PS][SS][1]=P+0x2000;
+      MemMap[PS][SS][2]=P;
+      MemMap[PS][SS][3]=P+0x2000;
+      MemMap[PS][SS][4]=P+0x4000;
+      MemMap[PS][SS][5]=P+0x6000;
+      MemMap[PS][SS][6]=P+0x4000;
+      MemMap[PS][SS][7]=P+0x6000;
       break;
 
     default:
       if(ROM64)
       {
         /* 64kB ROMs are loaded to fill slot: 0:1:2:3:4:5:6:7 */
-        MemMap[PS][SS][0]=ROMData[Slot];
-        MemMap[PS][SS][1]=ROMData[Slot]+0x2000;
-        MemMap[PS][SS][2]=ROMData[Slot]+0x4000;
-        MemMap[PS][SS][3]=ROMData[Slot]+0x6000;
-        MemMap[PS][SS][4]=ROMData[Slot]+0x8000;
-        MemMap[PS][SS][5]=ROMData[Slot]+0xA000;
-        MemMap[PS][SS][6]=ROMData[Slot]+0xC000;
-        MemMap[PS][SS][7]=ROMData[Slot]+0xE000;
+        MemMap[PS][SS][0]=P;
+        MemMap[PS][SS][1]=P+0x2000;
+        MemMap[PS][SS][2]=P+0x4000;
+        MemMap[PS][SS][3]=P+0x6000;
+        MemMap[PS][SS][4]=P+0x8000;
+        MemMap[PS][SS][5]=P+0xA000;
+        MemMap[PS][SS][6]=P+0xC000;
+        MemMap[PS][SS][7]=P+0xE000;
       }
       break;
   }
@@ -2744,7 +2759,7 @@ int LoadCart(const char *FileName,int Slot,int Type)
   /* Guess MegaROM mapper type if not given */
   if((Type>=MAP_GUESS)&&(ROMMask[Slot]+1>4))
   {
-    Type=GuessROM(ROMData[Slot],0x2000*(ROMMask[Slot]+1));
+    Type=GuessROM(P,0x2000*(ROMMask[Slot]+1));
     if(Slot<MAXCARTS) SETROMTYPE(Slot,Type);
   }
 
@@ -2770,13 +2785,13 @@ int LoadCart(const char *FileName,int Slot,int Type)
       memset(SRAMData[Slot],NORAM,0x4000);
 
     /* Generate SRAM file name and load SRAM contents */
-    if((SRAMName[Slot] = GetMemory(strlen(FileName)+5)))
+    if((SRAMName[Slot] = (char *)GetMemory(strlen(FileName)+5)))
     {
       /* Compose SRAM file name */
       strcpy(SRAMName[Slot],FileName);
-      P = (byte*)(const char*)strrchr(SRAMName[Slot],'.');
-      if(P)
-         strcpy((char*)P,".sav");
+      T = (byte*)(const char*)strrchr(SRAMName[Slot],'.');
+      if(T)
+         strcpy((char*)T,".sav");
       else
          strcat(SRAMName[Slot],".sav");
 
@@ -2819,6 +2834,34 @@ int LoadCart(const char *FileName,int Slot,int Type)
 
   /* Done loading cartridge */
   return(Pages);
+}
+
+/** LoadPAL() ************************************************/
+/** Load new palette from .PAL file. Returns number of      **/
+/** loaded colors on success, 0 on failure.                 **/
+/*************************************************************/
+int LoadPAL(const char *Name)
+{
+  static const char *Hex = "0123456789ABCDEF";
+  char S[256],*P,*T,*H;
+  FILE *F;
+  int J,I;
+
+  if(!(F=fopen(Name,"rb"))) return(0);
+
+  for(J=0;(J<16)&&fgets(S,sizeof(S),F);++J)
+  {
+    /* Skip white space and optional '#' character */
+    for(P=S;*P&&(*P<=' ');++P);
+    if(*P=='#') ++P;
+    /* Parse six hexadecimal digits */
+    for(T=P,I=0;*T&&(H=strchr(Hex,toupper(*T)));++T) I=(I<<4)+(H-Hex);
+    /* If we have got six digits, parse and set color */
+    if(T-P==6) SetColor(J,I>>16,(I>>8)&0xFF,I&0xFF);
+  }
+
+  fclose(F);
+  return(J);
 }
 
 #define SaveSTRUCT(Name) \
@@ -2874,7 +2917,7 @@ unsigned int SaveState(unsigned char *Buf,unsigned int MaxSize)
   State[J++] = VAddr;
   State[J++] = VKey;
   State[J++] = PKey;
-  State[J++] = WKey;
+  State[J++] = 0;          /* was WKey (deprecated) */
   State[J++] = IRQPending;
   State[J++] = ScanLine;
   State[J++] = RTCReg;
@@ -2952,7 +2995,7 @@ unsigned int LoadState(unsigned char *Buf,unsigned int MaxSize)
   VAddr      = State[J++];
   VKey       = State[J++];
   PKey       = State[J++];
-  WKey       = State[J++];
+  J++;                      /* was WKey = State[J++]; */
   IRQPending = State[J++];
   ScanLine   = State[J++];
   RTCReg     = State[J++];
@@ -2978,6 +3021,15 @@ unsigned int LoadState(unsigned char *Buf,unsigned int MaxSize)
   {
     ROMType[I] = State[J++];
     for(K=0;K<4;++K) ROMMapper[I][K]=State[J++];
+
+    /* Correction for older states */
+    if(ROMType[I]==MAP_FMPAC)
+      ROMMapper[I][1]=ROMMapper[I][0]|1;
+    else if((ROMType[I]==MAP_ASCII16)||(ROMType[I]==MAP_GEN16))
+    {
+      ROMMapper[I][1]=ROMMapper[I][0]|1;
+      ROMMapper[I][3]=ROMMapper[I][2]|1;
+    }
   }
 
   /* Set RAM mapper pages */

--- a/fMSX/MSX.h
+++ b/fMSX/MSX.h
@@ -6,7 +6,7 @@
 /** and MSX emulation itself. See Z80.h for #defines        **/
 /** related to Z80 emulation.                               **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2014                 **/
+/** Copyright (C) Marat Fayzullin 1994-2017                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/MSX.h
+++ b/fMSX/MSX.h
@@ -56,7 +56,7 @@ extern "C" {
 #define CPU_H240     (HREFRESH_240/6)
 #define CPU_H256     (HREFRESH_256/6)
 
-#define MAX_STASIZE  0x50000         /* Max. state data size */   
+#define MAX_STASIZE  0x48000         /* Max. state data size */   
 
 #define INT_IE0     0x01    /* VDP interrupt modes           */
 #define INT_IE1     0x02
@@ -92,7 +92,7 @@ extern "C" {
 
 #define FMPAC_MAGIC 0x694D  /* FMPAC SRAM "magic value"      */
 
-#define FMSX_PAGESIZE    0x4000L /* Size of a RAM page            */
+#define PGSIZE      0x4000L /* Size of a RAM page            */
 #define NORAM       0xFF    /* Byte to be returned from      */
                             /* non-existing pages and ports  */
 #define MAXSCREEN   12      /* Highest screen mode supported */
@@ -155,6 +155,7 @@ extern "C" {
 #define MSX_DRUMS     0x08000000 /* Hit MIDI drums for noise */
 #define MSX_PATCHBDOS 0x10000000 /* Patch DiskROM routines   */
 #define MSX_FIXEDFONT 0x20000000 /* Use fixed 8x8 text font  */
+#define MSX_MSXDOS2   0x40000000 /* Load MSXDOS2 ROM on boot */
 /*************************************************************/
 
 /** Keyboard codes and macros ********************************/
@@ -291,6 +292,12 @@ int LoadFile(const char *FileName);
 /** in 16kB pages on success, 0 on failure.                 **/
 /*************************************************************/
 int LoadCart(const char *FileName,int Slot,int Type);
+
+/** LoadPAL() ************************************************/
+/** Load new palette from .PAL file. Returns number of      **/
+/** loaded colors on success, 0 on failure.                 **/
+/*************************************************************/
+int LoadPAL(const char *Name);
 
 /** MakeFileName() *******************************************/
 /** Make a copy of the file name, replacing the extension.  **/

--- a/fMSX/V9938.c
+++ b/fMSX/V9938.c
@@ -5,7 +5,7 @@
 /** This file contains implementation for the V9938 special **/
 /** graphical operations.                                   **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2014                 **/
+/** Copyright (C) Marat Fayzullin 1994-2017                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/V9938.h
+++ b/fMSX/V9938.h
@@ -5,7 +5,7 @@
 /** This file contains declarations for V9938 special       **/
 /** graphical operations support implemented in V9938.c.    **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2014                 **/
+/** Copyright (C) Marat Fayzullin 1994-2017                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/Wide.h
+++ b/fMSX/Wide.h
@@ -7,7 +7,7 @@
 /** implementations. It also includes dummy sound drivers   **/
 /** for fMSX.                                               **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2014                 **/
+/** Copyright (C) Marat Fayzullin 1994-2017                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/


### PR DESCRIPTION
Apply missing parts of fMSX 3.9 > 4.9 upgrade done in 2017 (8d5f4a128e), while maintaining libretro-specific ports and refactorings added after that.

Works fine on my RPi3B+ ARMv8 and Linux x86 laptop - although I didn't do extensive testing. Let me know if you have testing requirements for accepting PRs.

A summary of the fMSX 3.9 > 4.9 additions in this PR:
- PSG/MIDI noise tweak
- EMULib: a few new effects (all destined to be removed anyway, since RA implements plenty shaders)
- some tweaks to floppy handling
- more extensive sprite support
- VDP writes handled differently
- detect BASIC ROMs
- support .PAL files
- make loading of MSX_MSXDOS2 configurable

For reference, a summary of 8d5f4a128e:
- add 20 files actually not needed in libretro (12 EMULib, 1 fMSX, 4+3 Unix)
  EMULib: Hunt.c Hunt.h Image.c ImageMux.h IPS.c IPS.h NetPlay.c NetPlay.h Record.c Record.h Rules.gcc Rules.Unix 
  fMSX: State.h
  .. all of these were removed in various commits over the years. Except State.h - which is included nowhere by now. 
- patch fMSX 3.9 vs. 4.9, _Z80 folder only_ (4 files)
- add whitespace to fMSX/MSX.c...

So folders EMULib and fMSX seem to have been forgotten/missed at that point.

An overview of lr-specific code that was kept:
 (i.e. output of diffing fMSX49 code against fmsx-libretro HEAD)
- 'register' modifiers
- WaitJoystick() empty
- ParseEffects()
- #ifdef's for older ports
- ZLIB
- VFS (rf* functions, RFILE, etc.) incl. some whitespace
- SndDriver
- a few #include's
- Verbose / printf
- state & cheats handling
- MSB vs. LSB