### PR TITLE
support all 8 specific values for fmsx_mapper_type_mode - part of #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,46 @@ fmsx
 this is a port of fMSX 4.9 to the libretro API
 
 source : http://fms.komkon.org/fMSX/
+
+
+## Recognized file extension
+* .rom .mx1 .mx2 .ROM .MX1 .MX2 - for ROM images
+* .dsk .DSK - for 360/720kB disk images
+* .cas .CAS - for fMSX tape files
+
+
+## Configuration options
+
+Specify these in your RetroArch core options:
+
+    fmsx_mode=MSX2+*|MSX1|MSX2
+    fmsx_video_mode=NTSC*|PAL
+    fmsx_mapper_type_mode=Guess Mapper Type A*|Guess Mapper Type B|Generic 8kB|Generic 16kB|Konami5 8kB|Konami4 8kB|ASCII 8kB|ASCII 16kB|GameMaster2|FMPAC
+    fmsx_ram_pages=Auto*|64KB|128KB|256KB|512KB
+    fmsx_vram_pages=Auto*|32KB|64KB|128KB|192KB
+
+A star (*) indicates this is the default setting.
+
+
+## BIOS
+These BIOS ROMs are required for execution:
+* MSX1: MSX.ROM
+* MSX2: MSX2.ROM, MSX2EXT.ROM
+* MSX2+: MSX2P.ROM, MSX2PEXT.ROM
+
+Optional; loaded when found:
+* DISK.ROM
+* FMPAC.ROM
+* KANJI.ROM
+* MSXDOS2.ROM (MSX2/2+)
+* PAINTER.ROM (MSX2/2+)
+* RS232.ROM
+* CMOS.ROM
+* GMASTER2.ROM, GMASTER.ROM
+
+
+## Technical details
+
+Video: 16bpp RGB565 272x228 (544x228 in 512px MSX2 screen modes).
+
+Audio: rendered in 48kHz 16b mono.

--- a/libretro.c
+++ b/libretro.c
@@ -406,7 +406,18 @@ void retro_set_environment(retro_environment_t cb)
    static const struct retro_variable vars[] = {
       { "fmsx_mode", "MSX Mode; MSX2+|MSX1|MSX2" },
       { "fmsx_video_mode", "MSX Video Mode; NTSC|PAL" },
-      { "fmsx_mapper_type_mode", "MSX Mapper Type Mode; Guess Mapper Type A|Guess Mapper Type B" },
+      { "fmsx_mapper_type_mode", "MSX Mapper Type Mode; "
+            "Guess Mapper Type A|"
+            "Guess Mapper Type B|"
+            "Generic 8kB|"
+            "Generic 16kB|"
+            "Konami5 8kB|"
+            "Konami4 8kB|"
+            "ASCII 8kB|"
+            "ASCII 16kB|"
+            "GameMaster2|"
+            "FMPAC"
+      },
       { "fmsx_ram_pages", "MSX Main Memory; Auto|64KB|128KB|256KB|512KB" },
       { "fmsx_vram_pages", "MSX Video Memory; Auto|32KB|64KB|128KB|192KB" },
       { NULL, NULL },
@@ -543,7 +554,25 @@ static void check_variables(void)
       if (strcmp(var.value, "Guess Mapper Type A") == 0)
          Mode |= MSX_GUESSA;
       else if (strcmp(var.value, "Guess Mapper Type B") == 0)
-         Mode |= MSX_GUESSB;
+         Mode |= MSX_GUESSB; // I guess this never works
+      else if (strcmp(var.value, "Generic 8kB") == 0)
+         SETROMTYPE(0,MAP_GEN8);
+      else if (strcmp(var.value, "Generic 16kB") == 0)
+         SETROMTYPE(0,MAP_GEN16);
+      else if (strcmp(var.value, "Konami5 8kB") == 0)
+         SETROMTYPE(0,MAP_KONAMI5);
+      else if (strcmp(var.value, "Konami4 8kB") == 0)
+         SETROMTYPE(0,MAP_KONAMI4);
+      else if (strcmp(var.value, "ASCII 8kB") == 0)
+         SETROMTYPE(0,MAP_ASCII8);
+      else if (strcmp(var.value, "ASCII 16kB") == 0)
+         SETROMTYPE(0,MAP_ASCII16);
+      else if (strcmp(var.value, "GameMaster2") == 0)
+         SETROMTYPE(0,MAP_GMASTER2);
+      else if (strcmp(var.value, "FMPAC") == 0)
+         SETROMTYPE(0,MAP_FMPAC);
+      else
+         Mode |= MSX_GUESSA;
    }
    else
    {


### PR DESCRIPTION
Support all 8 specific values for fmsx_mapper_type_mode (ASCII 8kB, Generic 16kB, etc.). As mentioned in #57. 