### PR TITLE
add fmsx_simbdos=No|Yes option

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -409,6 +409,7 @@ void retro_set_environment(retro_environment_t cb)
       { "fmsx_mapper_type_mode", "MSX Mapper Type Mode; Guess Mapper Type A|Guess Mapper Type B" },
       { "fmsx_ram_pages", "MSX Main Memory; Auto|64KB|128KB|256KB|512KB" },
       { "fmsx_vram_pages", "MSX Video Memory; Auto|32KB|64KB|128KB|192KB" },
+      { "fmsx_simbdos", "Simulate DiskROM disk access calls; No|Yes" },
       { NULL, NULL },
    };
 
@@ -549,6 +550,12 @@ static void check_variables(void)
    {
       Mode |= MSX_GUESSA;
    }
+
+   var.key = "fmsx_simbdos";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && strcmp(var.value, "Yes") == 0)
+      Mode |= MSX_PATCHBDOS;
 
    var.key = "fmsx_ram_pages";
    var.value = NULL;


### PR DESCRIPTION
To enable fMSX to take over DiskROM disk access routines, conform -simbdos/-wd1793 fMSX cmdline option. Part of #57. I'm not sure how useful this option is - feel free to reject this PR.