### PR TITLE
enable second joystick, and fix 2 small spelling issues

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -354,7 +354,7 @@ static void set_input_descriptors(void)
       { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,   "Stick Down" },
       { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "Stick Right" },
       { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,          "Fire A" },
-      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,           "FireB" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,          "Fire B" },
       { 0 },
    };
    struct retro_input_descriptor descriptors[32];
@@ -396,7 +396,7 @@ void retro_set_environment(retro_environment_t cb)
    { "Joystick",                       RETRO_DEVICE_JOYPAD },
    };
    static const struct retro_controller_description port1[] = {
-   { "joystick",                       RETRO_DEVICE_JOYPAD}
+   { "Joystick",                       RETRO_DEVICE_JOYPAD}
    };
    static const struct retro_controller_info ports[] = {
       { port0, 4 },
@@ -650,8 +650,8 @@ bool retro_load_game(const struct retro_game_info *info)
       CasName=NULL;
    }
 
-
-   SETJOYTYPE(0,1);
+   SETJOYTYPE(0,JOY_STICK);
+   SETJOYTYPE(1,JOY_STICK);
 
    fMSX_image.Cropped = 0;
    fMSX_image.D = 16;


### PR DESCRIPTION
Second joystick was already mapped into RetroArch, but never enabled on fMSX side.. Now I can finally play F1 Spirit side by side with my son ;)

In MSX.c, the following 2 lines are the reason behind joy2 never being enabled until now:
    /* If no joystick, return dummy value */
    if(L==JOY_NONE) return(0x7F);

The newly added line SETJOYTYPE(1,JOY_STICK); makes sure also joy2 is reported back to games.

This is part of #57. 