### PR TITLE
implement -auto fMSX cmdline option, as RA option 'fmsx_autospace'

### DIFF
--- a/fMSX/MSX.c
+++ b/fMSX/MSX.c
@@ -2072,9 +2072,6 @@ word LoopZ80(Z80 *R)
     /* Check keyboard */
     Keyboard();
 
-    /* Exit emulation if requested */
-    if(ExitNow) return(INT_QUIT);
-
     /* Check mouse in joystick port #1 */
     if(JOYTYPE(0)>=JOY_MOUSTICK)
     {
@@ -2124,6 +2121,9 @@ word LoopZ80(Z80 *R)
         /* Autofire FIRE-B if needed */
         if(OPTION(MSX_AUTOFIREB)) JoyState&=~(JST_FIREB|(JST_FIREB<<8));
       }
+
+    /* Exit emulation if requested */
+    if(ExitNow) return(INT_QUIT);
   }
 
   /* Return whatever interrupt is pending */

--- a/libretro.c
+++ b/libretro.c
@@ -424,6 +424,7 @@ void retro_set_environment(retro_environment_t cb)
       { "fmsx_ram_pages", "MSX Main Memory; Auto|64KB|128KB|256KB|512KB" },
       { "fmsx_vram_pages", "MSX Video Memory; Auto|32KB|64KB|128KB|192KB" },
       { "fmsx_simbdos", "Simulate DiskROM disk access calls; No|Yes" },
+      { "fmsx_autospace", "Use autofire on SPACE; No|Yes" },
       { NULL, NULL },
    };
 
@@ -588,6 +589,12 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && strcmp(var.value, "Yes") == 0)
       Mode |= MSX_PATCHBDOS;
+
+   var.key = "fmsx_autospace";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && strcmp(var.value, "Yes") == 0)
+      Mode |= MSX_AUTOSPACE;
 
    var.key = "fmsx_ram_pages";
    var.value = NULL;
@@ -857,7 +864,8 @@ void retro_run(void)
    }
 
    for (i=0; i < 130; i++)
-      KBD_RES(i);
+      if(i != KBD_SPACE || !(OPTION(MSX_AUTOSPACE)))
+         KBD_RES(i);
 
    joystate = 0;
 


### PR DESCRIPTION
This doesn't feel right though - is ALWAYS on. Also during boot and game start. 

This IS the way fMSX itself implements it, but I doubt if this feature is very useful.
Also, I had to fiddle with keyboard clearing (libretro.c#867) and the moment the emulation loop returns to libretro (MSX.c#2075/2124). 

Think hard if you really want to merge this..

Part of #57 