### PR TITLE
Migrate 5.1 to 5.3

### DIFF
--- a/EMULib/AY8910.c
+++ b/EMULib/AY8910.c
@@ -6,7 +6,7 @@
 /** produced by General Instruments, Yamaha, etc. See       **/
 /** AY8910.h for declarations.                              **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/AY8910.h
+++ b/EMULib/AY8910.h
@@ -6,7 +6,7 @@
 /** produced by General Instruments, Yamaha, etc. See       **/
 /** AY8910.c for the actual code.                           **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/EMULib.c
+++ b/EMULib/EMULib.c
@@ -5,7 +5,7 @@
 /** This file contains platform-independent implementation  **/
 /** part of the emulation library.                          **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/EMULib.h
+++ b/EMULib/EMULib.h
@@ -5,7 +5,7 @@
 /** This file contains platform-independent definitions and **/
 /** declarations for the emulation library.                 **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/FDIDisk.c
+++ b/EMULib/FDIDisk.c
@@ -6,7 +6,7 @@
 /** disk images in various formats. The internal format is  **/
 /** always .FDI. See FDIDisk.h for declarations.            **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2007-2016                 **/
+/** Copyright (C) Marat Fayzullin 2007-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/FDIDisk.h
+++ b/EMULib/FDIDisk.h
@@ -6,7 +6,7 @@
 /** disk images in various formats. The internal format is  **/
 /** always .FDI. See FDIDisk.c for the actual code.         **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2007-2016                 **/
+/** Copyright (C) Marat Fayzullin 2007-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Floppy.c
+++ b/EMULib/Floppy.c
@@ -5,7 +5,7 @@
 /** This file implements functions to operate on 720kB      **/
 /** floppy disk images. See Floppy.h for declarations.      **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2004-2016                 **/
+/** Copyright (C) Marat Fayzullin 2004-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Floppy.c
+++ b/EMULib/Floppy.c
@@ -90,7 +90,7 @@ static int FindFreeCluster(const byte *Dsk,int Start)
 /** Create disk image in Dsk or allocate memory when Dsk=0. **/
 /** Returns pointer to the disk image or 0 on failure.      **/
 /*************************************************************/
-byte *DSKCreate(byte *Dsk)
+byte *DSKCreate(byte *Dsk,const char *Label)
 {
   byte *FAT,*DIR,*DAT;
 
@@ -113,7 +113,8 @@ byte *DSKCreate(byte *Dsk)
   Dsk[0x00] = 0xC9;
   Dsk[0x01] = 0xC9;
   Dsk[0x02] = 0xC9;
-  memcpy(Dsk+3,"MSX-DISK",8);
+  memset(Dsk+3,0x00,8);
+  if(Label) strncpy((char *)(Dsk+3),Label,8);
   Dsk[0x0B] = DSK_SECTOR_SIZE&0xFF; 
   Dsk[0x0C] = (DSK_SECTOR_SIZE>>8)&0xFF;
   Dsk[0x0D] = DSK_SECS_PER_CLTR;
@@ -369,7 +370,7 @@ int DSKDelete(byte *Dsk,int ID)
 /** functions return pointer to disk contents on success or **/
 /** 0 on failure.                                           **/
 /*************************************************************/
-byte *DSKLoad(const char *Name,byte *Dsk)
+byte *DSKLoad(const char *Name,byte *Dsk,const char *Label)
 {
   byte *Dsk1,*Buf;
   char *Path,FN[32];
@@ -379,7 +380,7 @@ byte *DSKLoad(const char *Name,byte *Dsk)
   int J,I;
 
   /* Create disk image */
-  Dsk1=DSKCreate(Dsk);
+  Dsk1=DSKCreate(Dsk,Label);
   if(!Dsk1) return(0);
 
   /* If <Name> is a directory... */

--- a/EMULib/Floppy.h
+++ b/EMULib/Floppy.h
@@ -5,7 +5,7 @@
 /** This file declares functions to operate on 720kB        **/
 /** floppy disk images. See Floppy.c for implementation.    **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2004-2016                 **/
+/** Copyright (C) Marat Fayzullin 2004-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Floppy.h
+++ b/EMULib/Floppy.h
@@ -27,7 +27,7 @@ typedef unsigned char byte;
 /** Create disk image in Dsk or allocate memory when Dsk=0. **/
 /** Returns pointer to the disk image or 0 on failure.      **/
 /*************************************************************/
-byte *DSKCreate(byte *Dsk);
+byte *DSKCreate(byte *Dsk,const char *Label);
 
 /** DSKFile() ************************************************/
 /** Create file with a given name, return file ID or 0 on   **/
@@ -65,7 +65,7 @@ int DSKDelete(byte *Dsk,int ID);
 /** functions return pointer to disk contents on success or **/
 /** 0 on failure.                                           **/
 /*************************************************************/
-byte *DSKLoad(const char *Name,byte *Dsk);
+byte *DSKLoad(const char *Name,byte *Dsk,const char *Label);
 const byte *DSKSave(const char *Name,const byte *Dsk);
 
 #endif /* FLOPPY_H */

--- a/EMULib/I8255.c
+++ b/EMULib/I8255.c
@@ -6,7 +6,7 @@
 /** port interface (PPI) chip from Intel. See I8255.h for   **/
 /** declarations.                                           **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2001-2016                 **/
+/** Copyright (C) Marat Fayzullin 2001-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/I8255.h
+++ b/EMULib/I8255.h
@@ -6,7 +6,7 @@
 /** port interface (PPI) chip from Intel. See I8255.h for   **/
 /** the actual code.                                        **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2001-2016                 **/
+/** Copyright (C) Marat Fayzullin 2001-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/SCC.c
+++ b/EMULib/SCC.c
@@ -5,7 +5,7 @@
 /** This file contains emulation for the SCC sound chip     **/
 /** produced by Konami.                                     **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/SCC.h
+++ b/EMULib/SCC.h
@@ -5,7 +5,7 @@
 /** This file contains definitions and declarations for     **/
 /** routines in SCC.c.                                      **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Sound.c
+++ b/EMULib/Sound.c
@@ -5,7 +5,7 @@
 /** This file file implements core part of the sound API.   **/
 /** See Sound.h for declarations.                           **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/Sound.h
+++ b/EMULib/Sound.h
@@ -5,7 +5,7 @@
 /** This file defines standard sound generation API.        **/
 /** See Sound.c and the sound drivers for the code.         **/ 
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/WD1793.c
+++ b/EMULib/WD1793.c
@@ -6,7 +6,7 @@
 /** controller produced by Western Digital. See WD1793.h    **/
 /** for declarations.                                       **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2005-2016                 **/
+/** Copyright (C) Marat Fayzullin 2005-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/WD1793.h
+++ b/EMULib/WD1793.h
@@ -6,7 +6,7 @@
 /** controller produced by Western Digital. See WD1793.c    **/
 /** for implementation.                                     **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2005-2016                 **/
+/** Copyright (C) Marat Fayzullin 2005-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/YM2413.c
+++ b/EMULib/YM2413.c
@@ -6,7 +6,7 @@
 /** produced by Yamaha (also see OPL2, OPL3, OPL4 chips).   **/
 /** See YM2413.h for declarations.                          **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/EMULib/YM2413.h
+++ b/EMULib/YM2413.h
@@ -6,7 +6,7 @@
 /** produced by Yamaha (also see OPL2, OPL3, OPL4 chips).   **/
 /** See YM2413.h for the code.                              **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1996-2016                 **/
+/** Copyright (C) Marat Fayzullin 1996-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/Z80/Codes.h
+++ b/Z80/Codes.h
@@ -5,7 +5,7 @@
 /** This file contains implementation for the main table of **/
 /** Z80 commands. It is included from Z80.c.                **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/Z80/CodesCB.h
+++ b/Z80/CodesCB.h
@@ -5,7 +5,7 @@
 /** This file contains implementation for the CB table of   **/
 /** Z80 commands. It is included from Z80.c.                **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/Z80/CodesED.h
+++ b/Z80/CodesED.h
@@ -5,7 +5,7 @@
 /** This file contains implementation for the ED table of   **/
 /** Z80 commands. It is included from Z80.c.                **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/Z80/CodesXCB.h
+++ b/Z80/CodesXCB.h
@@ -5,7 +5,7 @@
 /** This file contains implementation for FD/DD-CB tables   **/
 /** of Z80 commands. It is included from Z80.c.             **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/Z80/CodesXX.h
+++ b/Z80/CodesXX.h
@@ -5,7 +5,7 @@
 /** This file contains implementation for FD/DD tables of   **/
 /** Z80 commands. It is included from Z80.c.                **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/Z80/ConDebug.c
+++ b/Z80/ConDebug.c
@@ -7,7 +7,7 @@
 /** ommitted, ConDebug.c just includes the default command  **/
 /** line based debugger (Debug.c).                          **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2005-2017                 **/
+/** Copyright (C) Marat Fayzullin 2005-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/Z80/Debug.c
+++ b/Z80/Debug.c
@@ -6,7 +6,7 @@
 /** the Z80 emulator which is called on each Z80 step when  **/
 /** Trap!=0.                                                **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1995-2017                 **/
+/** Copyright (C) Marat Fayzullin 1995-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/Z80/Tables.h
+++ b/Z80/Tables.h
@@ -7,7 +7,7 @@
 /** There are also timing tables for Z80 opcodes. This file **/
 /** is included from Z80.c.                                 **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/   
 /**     changes to this file.                               **/

--- a/Z80/Z80.c
+++ b/Z80/Z80.c
@@ -7,7 +7,7 @@
 /** LoopZ80(), and PatchZ80() functions to accomodate the   **/
 /** emulated machine's architecture.                        **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/Z80/Z80.h
+++ b/Z80/Z80.h
@@ -5,7 +5,7 @@
 /** This file contains declarations relevant to emulation   **/
 /** of Z80 CPU.                                             **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/Boot.h
+++ b/fMSX/Boot.h
@@ -5,7 +5,7 @@
 /** This file contains MSX boot sector image used to create **/
 /** new disk images during FORMAT operation.                **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/Common.h
+++ b/fMSX/Common.h
@@ -7,7 +7,7 @@
 /** implementations. It also includes dummy sound drivers   **/
 /** for fMSX.                                               **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/Common.h
+++ b/fMSX/Common.h
@@ -218,19 +218,27 @@ void Sprites(byte Y,pixel *Line)
           /* Draw left 8 pixels of the sprite */
           if(K&0xFF00)
           {
-            if(K&0x8000) P[0]=C;if(K&0x4000) P[1]=C;
-            if(K&0x2000) P[2]=C;if(K&0x1000) P[3]=C;
-            if(K&0x0800) P[4]=C;if(K&0x0400) P[5]=C;
-            if(K&0x0200) P[6]=C;if(K&0x0100) P[7]=C;
+            if(K&0x8000) P[0]=C;
+            if(K&0x4000) P[1]=C;
+            if(K&0x2000) P[2]=C;
+            if(K&0x1000) P[3]=C;
+            if(K&0x0800) P[4]=C;
+            if(K&0x0400) P[5]=C;
+            if(K&0x0200) P[6]=C;
+            if(K&0x0100) P[7]=C;
           }
 
           /* Draw right 8 pixels of the sprite */
           if(K&0x00FF)
           {
-            if(K&0x0080) P[8]=C; if(K&0x0040) P[9]=C;
-            if(K&0x0020) P[10]=C;if(K&0x0010) P[11]=C;
-            if(K&0x0008) P[12]=C;if(K&0x0004) P[13]=C;
-            if(K&0x0002) P[14]=C;if(K&0x0001) P[15]=C;
+            if(K&0x0080) P[8]=C;
+            if(K&0x0040) P[9]=C;
+            if(K&0x0020) P[10]=C;
+            if(K&0x0010) P[11]=C;
+            if(K&0x0008) P[12]=C;
+            if(K&0x0004) P[13]=C;
+            if(K&0x0002) P[14]=C;
+            if(K&0x0001) P[15]=C;
           }
         }
       }
@@ -340,17 +348,25 @@ void ColorSprites(byte Y,byte *ZBuf)
           }
           else
           {
-            if(J&0x80) P[0]|=C;if(J&0x40) P[1]|=C;
-            if(J&0x20) P[2]|=C;if(J&0x10) P[3]|=C;
-            if(J&0x08) P[4]|=C;if(J&0x04) P[5]|=C;
-            if(J&0x02) P[6]|=C;if(J&0x01) P[7]|=C;
+            if(J&0x80) P[0]|=C;
+            if(J&0x40) P[1]|=C;
+            if(J&0x20) P[2]|=C;
+            if(J&0x10) P[3]|=C;
+            if(J&0x08) P[4]|=C;
+            if(J&0x04) P[5]|=C;
+            if(J&0x02) P[6]|=C;
+            if(J&0x01) P[7]|=C;
             if(IH>8)
             {
               J=PT[16];
-              if(J&0x80) P[8]|=C; if(J&0x40) P[9]|=C;
-              if(J&0x20) P[10]|=C;if(J&0x10) P[11]|=C;
-              if(J&0x08) P[12]|=C;if(J&0x04) P[13]|=C;
-              if(J&0x02) P[14]|=C;if(J&0x01) P[15]|=C;
+              if(J&0x80) P[8]|=C;
+              if(J&0x40) P[9]|=C;
+              if(J&0x20) P[10]|=C;
+              if(J&0x10) P[11]|=C;
+              if(J&0x08) P[12]|=C;
+              if(J&0x04) P[13]|=C;
+              if(J&0x02) P[14]|=C;
+              if(J&0x01) P[15]|=C;
             }
           }
         }
@@ -358,32 +374,48 @@ void ColorSprites(byte Y,byte *ZBuf)
         {
           if(OH>IH)
           {
-            if(J&0x80) P[0]=P[1]=C;  if(J&0x40) P[2]=P[3]=C;
-            if(J&0x20) P[4]=P[5]=C;  if(J&0x10) P[6]=P[7]=C;
-            if(J&0x08) P[8]=P[9]=C;  if(J&0x04) P[10]=P[11]=C;
-            if(J&0x02) P[12]=P[13]=C;if(J&0x01) P[14]=P[15]=C;
+            if(J&0x80) P[0]=P[1]=C;
+            if(J&0x40) P[2]=P[3]=C;
+            if(J&0x20) P[4]=P[5]=C;
+            if(J&0x10) P[6]=P[7]=C;
+            if(J&0x08) P[8]=P[9]=C;
+            if(J&0x04) P[10]=P[11]=C;
+            if(J&0x02) P[12]=P[13]=C;
+            if(J&0x01) P[14]=P[15]=C;
             if(IH>8)
             {
               J=PT[16];
-              if(J&0x80) P[16]=P[17]=C;if(J&0x40) P[18]=P[19]=C;
-              if(J&0x20) P[20]=P[21]=C;if(J&0x10) P[22]=P[23]=C;
-              if(J&0x08) P[24]=P[25]=C;if(J&0x04) P[26]=P[27]=C;
-              if(J&0x02) P[28]=P[29]=C;if(J&0x01) P[30]=P[31]=C;
+              if(J&0x80) P[16]=P[17]=C;
+              if(J&0x40) P[18]=P[19]=C;
+              if(J&0x20) P[20]=P[21]=C;
+              if(J&0x10) P[22]=P[23]=C;
+              if(J&0x08) P[24]=P[25]=C;
+              if(J&0x04) P[26]=P[27]=C;
+              if(J&0x02) P[28]=P[29]=C;
+              if(J&0x01) P[30]=P[31]=C;
             }
           }
           else
           {
-            if(J&0x80) P[0]=C;if(J&0x40) P[1]=C;
-            if(J&0x20) P[2]=C;if(J&0x10) P[3]=C;
-            if(J&0x08) P[4]=C;if(J&0x04) P[5]=C;
-            if(J&0x02) P[6]=C;if(J&0x01) P[7]=C;
+            if(J&0x80) P[0]=C;
+            if(J&0x40) P[1]=C;
+            if(J&0x20) P[2]=C;
+            if(J&0x10) P[3]=C;
+            if(J&0x08) P[4]=C;
+            if(J&0x04) P[5]=C;
+            if(J&0x02) P[6]=C;
+            if(J&0x01) P[7]=C;
             if(IH>8)
             {
               J=PT[16];
-              if(J&0x80) P[8]=C; if(J&0x40) P[9]=C;
-              if(J&0x20) P[10]=C;if(J&0x10) P[11]=C;
-              if(J&0x08) P[12]=C;if(J&0x04) P[13]=C;
-              if(J&0x02) P[14]=C;if(J&0x01) P[15]=C;
+              if(J&0x80) P[8]=C;
+              if(J&0x40) P[9]=C;
+              if(J&0x20) P[10]=C;
+              if(J&0x10) P[11]=C;
+              if(J&0x08) P[12]=C;
+              if(J&0x04) P[13]=C;
+              if(J&0x02) P[14]=C;
+              if(J&0x01) P[15]=C;
             }
           }
         }

--- a/fMSX/CommonMux.h
+++ b/fMSX/CommonMux.h
@@ -6,7 +6,7 @@
 /** possible screen depth. It includes common driver code   **/
 /** from Common.h and Wide.h.                               **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/I8251.c
+++ b/fMSX/I8251.c
@@ -6,7 +6,7 @@
 /** chip and the 8253 timer chip implementing a generic     **/
 /** RS232 interface.                                        **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2004-2017                 **/
+/** Copyright (C) Marat Fayzullin 2004-2018                 **/
 /**               Maarten ter Huurne 2000                   **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/

--- a/fMSX/I8251.h
+++ b/fMSX/I8251.h
@@ -5,7 +5,7 @@
 /** This file contains definitions and declarations for     **/
 /** routines in I8251.c.                                    **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 2004-2017                 **/
+/** Copyright (C) Marat Fayzullin 2004-2018                 **/
 /**               Maarten ter Huurne 2000                   **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/

--- a/fMSX/MSX.c
+++ b/fMSX/MSX.c
@@ -7,7 +7,7 @@
 /** etc. Initialization code and definitions needed for the **/
 /** machine-dependent drivers are also here.                **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/MSX.c
+++ b/fMSX/MSX.c
@@ -2328,7 +2328,7 @@ byte ChangeDisk(byte N,const char *FileName)
     );
 
   /* If FileName not empty, treat it as directory, otherwise new disk */
-  if(P&&!(*FileName? DSKLoad(FileName,P):DSKCreate(P)))
+  if(P&&!(*FileName? DSKLoad(FileName,P,"MSX-DISK"):DSKCreate(P,"MSX-DISK")))
   { EjectFDI(&FDD[N]);return(0); }
 
   /* Done */

--- a/fMSX/MSX.h
+++ b/fMSX/MSX.h
@@ -6,7 +6,7 @@
 /** and MSX emulation itself. See Z80.h for #defines        **/
 /** related to Z80 emulation.                               **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/
@@ -401,6 +401,7 @@ void ResetCheats(void);
 /** query (3).                                              **/
 /*************************************************************/
 int Cheats(int Switch);
+
 /** SaveState() **********************************************/
 /** Save emulation state to a memory buffer. Returns size   **/
 /** on success, 0 on failure.                               **/

--- a/fMSX/State.h
+++ b/fMSX/State.h
@@ -5,7 +5,7 @@
 /** This file contains routines to save and load emulation  **/
 /** state.                                                  **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     The contents of this file are property of Marat     **/
 /**     Fayzullin and should only be used as agreed with    **/
 /**     him. The file is confidential. Absolutely no        **/

--- a/fMSX/V9938.c
+++ b/fMSX/V9938.c
@@ -5,7 +5,7 @@
 /** This file contains implementation for the V9938 special **/
 /** graphical operations.                                   **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/V9938.h
+++ b/fMSX/V9938.h
@@ -5,7 +5,7 @@
 /** This file contains declarations for V9938 special       **/
 /** graphical operations support implemented in V9938.c.    **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/

--- a/fMSX/Wide.h
+++ b/fMSX/Wide.h
@@ -7,7 +7,7 @@
 /** implementations. It also includes dummy sound drivers   **/
 /** for fMSX.                                               **/
 /**                                                         **/
-/** Copyright (C) Marat Fayzullin 1994-2017                 **/
+/** Copyright (C) Marat Fayzullin 1994-2018                 **/
 /**     You are not allowed to distribute this software     **/
 /**     commercially. Please, notify me, if you make any    **/
 /**     changes to this file.                               **/


### PR DESCRIPTION
Part of #71
 
fMSX changelog, filtered on applicable items:

New in fMSX 5.3
    Replaced -DNO_WAVE_INTERPOLATION with -DWAVE_INTERPOLATION, off by default.

New in fMSX 5.2
    -

Unmentioned in these changes are:
- some whitespace (Common.h)
- disk label refactoring (extract parameter)