### PR TITLE
fMSX 5.8 > 5.9 upgrade

### DIFF
--- a/EMULib/EMULib.h
+++ b/EMULib/EMULib.h
@@ -253,6 +253,11 @@ void ScaleImage(Image *Dst,const Image *Src,int X,int Y,int W,int H);
 /*************************************************************/
 unsigned int ARMScaleImage(Image *Dst,Image *Src,int X,int Y,int W,int H,int Attrs);
 
+/** InterpolateImage() ***************************************/
+/** Scale image Src into Dst using linear interpolation.    **/
+/*************************************************************/
+void InterpolateImage(Image *Dst,const Image *Src,int X,int Y,int W,int H);
+
 /** TelevizeImage() ******************************************/
 /** Create televizion effect on the image.                  **/
 /*************************************************************/

--- a/EMULib/FDIDisk.h
+++ b/EMULib/FDIDisk.h
@@ -16,21 +16,28 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+                              /* SaveFDI() result:           */
+#define FDI_SAVE_FAILED    0  /* Failed saving disk image    */
+#define FDI_SAVE_TRUNCATED 1  /* Truncated data while saving */
+#define FDI_SAVE_PADDED    2  /* Padded data while saving    */
+#define FDI_SAVE_OK        3  /* Succeeded saving disk image */
 
+                           /* Supported disk image formats:  */
 #define FMT_AUTO   0       /* Determine format automatically */                   
 #define FMT_IMG    1       /* ZX Spectrum disk               */             
-#define FMT_MGT    2       /* ZX Spectrum disk               */             
+#define FMT_MGT    2       /* ZX Spectrum disk, same as .DSK */             
 #define FMT_TRD    3       /* ZX Spectrum TRDOS disk         */
 #define FMT_FDI    4       /* Generic FDI image              */ 
 #define FMT_SCL    5       /* ZX Spectrum TRDOS disk         */
 #define FMT_HOBETA 6       /* ZX Spectrum HoBeta disk        */
 #define FMT_MSXDSK 7       /* MSX disk                       */          
-#define FMT_DSK    7       /* MSX disk (deprecated)          */          
 #define FMT_CPCDSK 8       /* CPC disk                       */          
 #define FMT_SF7000 9       /* Sega SF-7000 disk              */ 
 #define FMT_SAMDSK 10      /* Sam Coupe disk                 */    
 #define FMT_ADMDSK 11      /* Coleco Adam disk               */  
 #define FMT_DDP    12      /* Coleco Adam tape               */  
+#define FMT_SAD    13      /* Sam Coupe disk                 */
+#define FMT_DSK    14      /* Generic raw disk image         */
 
 #define SEEK_DELETED (0x40000000)
 
@@ -77,6 +84,13 @@ void EjectFDI(FDIDisk *D);
 /*************************************************************/
 byte *NewFDI(FDIDisk *D,int Sides,int Tracks,int Sectors,int SecSize);
 
+/** FormatFDI() ***********************************************/
+/** Allocate memory and create new standard disk image for a **/
+/** given format. Returns disk data pointer on success, 0 on **/
+/** failure.                                                 **/
+/**************************************************************/
+byte *FormatFDI(FDIDisk *D,int Format);
+
 /** LoadFDI() ************************************************/
 /** Load a disk image from a given file, in a given format  **/
 /** (see FMT_* #defines). Guess format from the file name   **/
@@ -89,8 +103,10 @@ int LoadFDI(FDIDisk *D,const char *FileName,int Format);
 /** SaveFDI() ************************************************/
 /** Save a disk image to a given file, in a given format    **/
 /** (see FMT_* #defines). Use the original format when      **/
-/** when Format=FMT_AUTO. Returns format ID on success or   **/
-/** 0 on failure.                                           **/
+/** when Format=FMT_AUTO. Returns FDI_SAVE_OK on success,   **/
+/** FDI_SAVE_PADDED if any sectors were padded,             **/
+/** FDI_SAVE_TRUNCATED if any sectors were truncated,       **/
+/** FDI_SAVE_FAILED (0) if failed.                          **/
 /*************************************************************/
 int SaveFDI(FDIDisk *D,const char *FileName,int Format);
 
@@ -105,13 +121,6 @@ byte *SeekFDI(FDIDisk *D,int Side,int Track,int SideID,int TrackID,int SectorID)
 /** sector address on success or 0 on failure.              **/
 /*************************************************************/
 byte *LinearFDI(FDIDisk *D,int SectorN);
-
-/** FormatFDI() ***********************************************/
-/** Allocate memory and create new standard disk image for a **/
-/** given format. Returns disk data pointer on success, 0 on **/
-/** failure.                                                 **/
-/**************************************************************/
-byte *FormatFDI(FDIDisk *D,int Format);
 
 #ifdef __cplusplus
 }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 fmsx
 ====
 
-this is a port of fMSX 5.1 to the libretro API
+This is a port of Marat Fayzullin's fMSX 5.9 to the libretro API.
 
-source : http://fms.komkon.org/fMSX/
+Source : http://fms.komkon.org/fMSX/
 
 
 ## Recognized file extension
 * .rom .mx1 .mx2 .ROM .MX1 .MX2 - for ROM images
-* .dsk .DSK - for 360/720kB disk images
+* .dsk .DSK - for FAT12 360/720kB disk images
 * .cas .CAS - for fMSX tape files
 
 
@@ -50,5 +50,6 @@ Video: 16bpp RGB565 272x228 (544x228 in 512px MSX2 screen modes). This includes 
 - vertical: 192 or 212
 
 Audio: rendered in 48kHz 16b mono.
+fMSX emulates PSG, SCC and FM-PAC.
 
 Framerate: NTSC (US/JP) implies 60Hz - thus 60FPS, PAL (EU) implies 50Hz (=50FPS). Gameplay and audio actually becomes 17% slower when switching from NTSC to PAL - just like on a real MSX.

--- a/Z80/Z80.c
+++ b/Z80/Z80.c
@@ -600,7 +600,9 @@ word RunZ80(Z80 *R)
     if(R->PC.W==R->Trap) R->Trace=1;
     /* Call single-step debugger, exit if requested */
     if(R->Trace)
+    {
       if(!DebugZ80(R)) return(R->PC.W);
+    }
 #endif
 
     /* Read opcode and count cycles */

--- a/fMSX/MSX.c
+++ b/fMSX/MSX.c
@@ -486,7 +486,7 @@ int StartMSX(int NewMode,int NewRAMPages,int NewVRAMPages)
   if(!RAMPages||!VRAMPages) return(0);
 
   /* Change to the program directory */
-  if(ProgDir) chdir(ProgDir);
+  if(ProgDir && chdir(ProgDir));
 
   /* Try loading font */
   if(FNTName)
@@ -536,7 +536,7 @@ int StartMSX(int NewMode,int NewRAMPages,int NewVRAMPages)
   }
 
   /* We are now back to working directory */
-  if(WorkDir) chdir(WorkDir);
+  if(WorkDir && chdir(WorkDir));
 
   /* For each user cartridge slot, try loading cartridge */
   for(J=0;J<MAXCARTS;++J) LoadCart(ROMName[J],J,ROMGUESS(J)|ROMTYPE(J));
@@ -586,7 +586,7 @@ void TrashMSX(void)
   int J;
 
   /* CMOS.ROM is saved in the program directory */
-  if(ProgDir) chdir(ProgDir);
+  if(ProgDir && chdir(ProgDir));
 
   /* Save CMOS RAM, if present */
   if(SaveCMOS)
@@ -600,7 +600,7 @@ void TrashMSX(void)
   }
 
   /* Change back to working directory */
-  if(WorkDir) chdir(WorkDir);
+  if(WorkDir && chdir(WorkDir));
 
   /* Eject disks, free disk buffers */
   Reset1793(&FDC,FDD,WD1793_EJECT);
@@ -662,7 +662,7 @@ int ResetMSX(int NewMode,int NewRAMPages,int NewVRAMPages)
   if((Mode^NewMode)&MSX_MODEL)
   {
     /* Change to the program directory */
-    if(ProgDir) chdir(ProgDir);
+    if(ProgDir && chdir(ProgDir));
 
     switch(NewMode&MSX_MODEL)
     {
@@ -734,7 +734,7 @@ int ResetMSX(int NewMode,int NewRAMPages,int NewVRAMPages)
     }
 
     /* Change to the working directory */
-    if(WorkDir) chdir(WorkDir);
+    if(WorkDir && chdir(WorkDir));
   }
 
   /* If hardware model changed ok, patch freshly loaded BIOS */
@@ -752,13 +752,13 @@ int ResetMSX(int NewMode,int NewRAMPages,int NewVRAMPages)
   if((Mode^NewMode)&MSX_PATCHBDOS)
   {
     /* Change to the program directory */
-    if(ProgDir) chdir(ProgDir);
+    if(ProgDir && chdir(ProgDir));
 
     /* Try loading DiskROM */
     P1=LoadROM("DISK.ROM",0x4000,0);
 
     /* Change to the working directory */
-    if(WorkDir) chdir(WorkDir);
+    if(WorkDir && chdir(WorkDir));
 
     /* If failed loading DiskROM, ignore the new PATCHBDOS bit */
     if(!P1) NewMode=(NewMode&~MSX_PATCHBDOS)|(Mode&MSX_PATCHBDOS);
@@ -2327,7 +2327,7 @@ byte ChangeDisk(byte N,const char *FileName)
   }
 
   /* If failed opening existing image, create a new 720kB disk image */
-  P = FormatFDI(&FDD[N],FMT_DSK);
+  P = FormatFDI(&FDD[N],FMT_MSXDSK);
 
   /* If FileName not empty, treat it as directory, otherwise new disk */
   if(P&&!(*FileName? DSKLoad(FileName,P,"MSX-DISK"):DSKCreate(P,"MSX-DISK")))


### PR DESCRIPTION
Part of #71 

Filtered fMSX changelog:

New in fMSX 5.9
    -

Unmentioned in the fMSX changelog:
- EMULib disk formats: a.o. support second Sam Coupé disk type (not applicable to MSX)

Additionally:
- fix 8 'unused result' warnings