### PR TITLE
finalize removal of "MIDI logging"

### DIFF
--- a/EMULib/AY8910.c
+++ b/EMULib/AY8910.c
@@ -249,9 +249,7 @@ void Loop8910(AY8910 *D,int uSec)
 /** Flush all accumulated changes by issuing Sound() calls  **/
 /** and set the synchronization on/off. The second argument **/
 /** should be AY8910_SYNC/AY8910_ASYNC to set/reset sync,   **/
-/** or AY8910_FLUSH to leave sync mode as it is. To emulate **/
-/** noise channels with MIDI drums, OR second argument with **/
-/** AY8910_DRUMS.                                           **/
+/** or AY8910_FLUSH to leave sync mode as it is.            **/
 /*************************************************************/
 void Sync8910(AY8910 *D,byte Sync)
 {
@@ -259,11 +257,10 @@ void Sync8910(AY8910 *D,byte Sync)
   int Freq,Volume,Drums;
 
   /* Update sync/async mode */
-  I = Sync&~AY8910_DRUMS;
+  I = Sync;
   if(I!=AY8910_FLUSH) D->Sync=I;
 
-  /* If hitting drums, always compute noise channels */
-  I = D->Changed|(Sync&AY8910_DRUMS? 0x38:0x00);
+  I = D->Changed;
 
   /* For every changed channel... */
   for(J=0,Drums=0;I&&(J<AY8910_CHANNELS);++J,I>>=1)

--- a/EMULib/AY8910.h
+++ b/EMULib/AY8910.h
@@ -22,7 +22,6 @@ extern "C" {
 #define AY8910_ASYNC    0      /* Asynchronous emulation     */
 #define AY8910_SYNC     1      /* Synchronous emulation      */
 #define AY8910_FLUSH    2      /* Flush buffers only         */
-#define AY8910_DRUMS    0x80   /* Hit drums for noise chnls  */
 
 #ifndef BYTE_TYPE_DEFINED
 #define BYTE_TYPE_DEFINED
@@ -83,9 +82,7 @@ byte RdData8910(AY8910 *D);
 /** Flush all accumulated changes by issuing Sound() calls  **/
 /** and set the synchronization on/off. The second argument **/
 /** should be AY8910_SYNC/AY8910_ASYNC to set/reset sync,   **/
-/** or AY8910_FLUSH to leave sync mode as it is. To emulate **/
-/** noise channels with MIDI drums, OR second argument with **/
-/** AY8910_DRUMS.                                           **/
+/** or AY8910_FLUSH to leave sync mode as it is.            **/
 /*************************************************************/
 void Sync8910(AY8910 *D,byte Sync);
 

--- a/EMULib/EMULib.h
+++ b/EMULib/EMULib.h
@@ -50,6 +50,12 @@
 #define MSE_XPOS     0x0000FFFF
 
 /** Sound ****************************************************/
+// fMSX emulates:
+// - AY8910 PSG: 3 melodic + 3 noise
+// - YM2413 OPLL: 9 FM sound channels, or 6 music + 5 drums
+// - SCC: 5 wave channels
+// fMSX does not support FM-PAC drums nor instruments (uses triangle waves), and plays either FM-PAC or SCC.
+// Thus: either 15, 12 or 11 channels active at once.
 #define SND_CHANNELS    16     /* Number of sound channels   */
 #define SND_BITS        8
 #define SND_BUFSIZE     (1<<SND_BITS)

--- a/EMULib/Sound.h
+++ b/EMULib/Sound.h
@@ -26,23 +26,9 @@ extern "C" {
 #define SND_NOISE       2      /* White noise                */
 #define SND_PERIODIC    3      /* Periodic noise (not im-ed) */
 #define SND_WAVE        4      /* Wave sound set by SetWave()*/
-#define SND_MIDI        0x100  /* MIDI instrument (ORable)   */
 
                                /* Drum() arguments:          */
 #define DRM_CLICK       0      /* Click (default)            */
-#define DRM_MIDI        0x100  /* MIDI drum (ORable)         */
-
-                               /* MIDI characteristics:      */
-#define MIDI_CHANNELS   16     /* Number of MIDI channels    */
-#define MIDI_MINFREQ    9      /* Min MIDI frequency (Hz)    */
-#define MIDI_MAXFREQ    12285  /* Max MIDI frequency (Hz)    */
-#define MIDI_DIVISIONS  1000   /* Number of ticks per second */
-
-                               /* MIDILogging() arguments:   */
-#define MIDI_OFF        0      /* Turn MIDI logging off      */
-#define MIDI_ON         1      /* Turn MIDI logging on       */
-#define MIDI_TOGGLE     2      /* Toggle MIDI logging        */
-#define MIDI_QUERY      3      /* Query MIDI logging status  */
 
 /** InitSound() **********************************************/
 /** Initialize RenderSound() with given parameters.         **/
@@ -117,10 +103,6 @@ const signed char *GetWave(int Channel);
 /** Get current sampling rate used for synthesis.           **/
 /*************************************************************/
 unsigned int GetSndRate(void);
-
-#if !defined(MSDOS) & !defined(UNIX) & !defined(MAEMO) & !defined(WINDOWS) & !defined(S60) & !defined(UIQ) && !defined(ANDROID)
-#define SND_CHANNELS MIDI_CHANNELS         /* Default number */
-#endif
 
 #ifdef __cplusplus
 }

--- a/EMULib/YM2413.c
+++ b/EMULib/YM2413.c
@@ -16,90 +16,6 @@
 #include "Sound.h"
 #include <string.h>
 
-/** Patches2413() ********************************************/
-/** MIDI instruments corresponding to the OPLL patches.     **/
-/*************************************************************/
-static const byte Patches2413[16] =
-{
-      /*** OPLL ***/    /*** MIDI ***/
-  90, /* Original */    /* User (Polysynth) */
-  40, /* Violin */      /* Violin */
-  27, /* Guitar */      /* Electric Guitar (clean) */
-  1,  /* Piano */       /* Bright Acoustic Piano */
-  73, /* Flute */       /* Flute */
-  71, /* Clarinet */    /* Clarinet */
-  68, /* Oboe */        /* Oboe */
-  56, /* Trumpet */     /* Trumpet */
-  20, /* Organ */       /* Reed Organ */
-  58, /* Horn */        /* Tuba */
-  50, /* Synthesizer */ /* Synth Strings 1 */
-  6,  /* Harpsichord */ /* Harpsichord */
-  11, /* Vibraphone */  /* Vibraphone */
-  38, /* Synth Bass */  /* Synth Bass 1 */
-  34, /* Wood Bass */   /* Electric Bass (pick) */
-  33  /* Elec Guitar */ /* Electric Bass (finger) */
-};
-
-/** Drums2413() **********************************************/
-/** MIDI instruments corresponding to the OPLL drums.       **/
-/*************************************************************/
-static const byte Drums2413[5] =
-{
-      /*** OPLL ***/    /*** MIDI ***/
-  42, /* High Hat */    /* Closed Hi Hat */
-  49, /* Top Cymbal */  /* Crash Cymbal 1 */
-  47, /* Tom-Tom */     /* Low-Mid Tom */
-  40, /* Snare Drum */  /* Electric Snare */
-  36  /* Bass Drum */   /* Bass Drum 1 */
-};
-
-/** Synth2413() **********************************************/
-/** Synthesizer parameters corresponding to OPLL patches.   **/
-/*************************************************************/
-#if 0
-static const byte Synth2413[19*16] =
-{
-  0x49,0x4c,0x4c,0x32,0x00,0x00,0x00,0x00,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x61,0x61,0x1e,0x17,0xf0,0x7f,0x00,0x17,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x13,0x41,0x16,0x0e,0xfd,0xf4,0x23,0x23,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x03,0x01,0x9a,0x04,0xf3,0xf3,0x13,0xf3,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x11,0x61,0x0e,0x07,0xfa,0x64,0x70,0x17,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x22,0x21,0x1e,0x06,0xf0,0x76,0x00,0x28,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x21,0x22,0x16,0x05,0xf0,0x71,0x00,0x18,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x21,0x61,0x1d,0x07,0x82,0x80,0x17,0x17,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x23,0x21,0x2d,0x16,0x90,0x90,0x00,0x07,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x21,0x21,0x1b,0x06,0x64,0x65,0x10,0x17,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x21,0x21,0x0b,0x1a,0x85,0xa0,0x70,0x07,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x23,0x01,0x83,0x10,0xff,0xb4,0x10,0xf4,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x97,0xc1,0x20,0x07,0xff,0xf4,0x22,0x22,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x61,0x00,0x0c,0x05,0xc2,0xf6,0x40,0x44,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x01,0x01,0x56,0x03,0x94,0xc2,0x03,0x12,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x21,0x01,0x89,0x03,0xf1,0xe4,0xf0,0x23,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x07,0x21,0x14,0x00,0xee,0xf8,0xff,0xf8,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x01,0x31,0x00,0x00,0xf8,0xf7,0xf8,0xf7,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-  0x25,0x11,0x00,0x00,0xf8,0xfa,0xf8,0x55,
-  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
-};
-#endif
-
 /** Reset2413() **********************************************/
 /** Reset the sound chip and use sound channels from the    **/
 /** one given in First.                                     **/
@@ -123,8 +39,6 @@ void Reset2413(YM2413 *D,int First)
   D->First    = First;
   D->Sync     = YM2413_ASYNC;
   D->Changed  = (1<<YM2413_CHANNELS)-1;
-  D->PChanged = (1<<YM2413_CHANNELS)-1;
-  D->DChanged = 0x1F;
   D->Latch    = 0;
 }
 
@@ -162,14 +76,12 @@ void Write2413(YM2413 *D,byte R,byte V)
   switch(R>>4)
   {
     case 0:
-      switch(C)
+      switch(C) // register 0-7 User Tone not supported by fMSX
       {
-        case 0x0E:
+        case 0x0E: // drums - not supported by fMSX, except for muting ch.6-8
           if(V==D->R[R]) return;
           /* Keep all drums off when drum mode is off */
           if(!(V&0x20)) V&=0xE0;
-          /* Mark all activated drums as changed */
-          D->DChanged|=(V^D->R[R])&0x1F;
           /* If drum mode was turned on... */
           if((V^D->R[R])&V&0x20)
           {
@@ -183,7 +95,7 @@ void Write2413(YM2413 *D,byte R,byte V)
       }
       break;
 
-    case 1:
+    case 1: // frequency LSB
       if((C>8)||(V==D->R[R])) return;
       if(!YM2413_DRUMS(D)||(C<6))
         if(D->R[R+0x10]&0x10)
@@ -200,7 +112,7 @@ void Write2413(YM2413 *D,byte R,byte V)
       /* Done */
       break;
 
-    case 2:
+    case 2: // frequency MSB, octave, key on/off, sustain on/off (last 2 ignored)
       if(C>8) return;
       if(!YM2413_DRUMS(D)||(C<6))
       {
@@ -220,10 +132,8 @@ void Write2413(YM2413 *D,byte R,byte V)
       /* Done */
       break;
 
-    case 3:
+    case 3: // instrument & volume - instrument ignored
       if((C>8)||(V==D->R[R])) return;
-      /* Register any patch changes */
-      if((V^D->R[R])&0xF0) D->PChanged|=1<<C;
       /* Register any volume changes */
       if((V^D->R[R])&0x0F)
       {
@@ -232,14 +142,6 @@ void Write2413(YM2413 *D,byte R,byte V)
         /* Mark channel as changed */
         D->Changed|=1<<C;
       }
-      /* Register drum volume changes */
-      if(YM2413_DRUMS(D))
-        switch(C)
-        {
-          case 6: D->DChanged|=0x10&D->R[0x0E];break;
-          case 7: D->DChanged|=0x09&D->R[0x0E];break;
-          case 8: D->DChanged|=0x06&D->R[0x0E];break;
-        }
       /* Done */
       break;
   }
@@ -248,7 +150,7 @@ void Write2413(YM2413 *D,byte R,byte V)
   D->R[R]=V;
 
   /* For asynchronous mode, make Sound() calls right away */
-  if(!D->Sync&&(D->Changed||D->PChanged||D->DChanged))
+  if(!D->Sync&&(D->Changed))
     Sync2413(D,YM2413_FLUSH);
 }
 
@@ -265,17 +167,9 @@ void Sync2413(YM2413 *D,byte Sync)
   /* Change sync mode as requested */
   if(Sync!=YM2413_FLUSH) D->Sync=Sync;
 
-  /* Convert channel instrument changes into SetSound() calls */
-  for(J=0,I=D->PChanged;I&&(J<YM2413_CHANNELS);++J,I>>=1)
-    if(I&1) SetSound(J+D->First,SND_MIDI|Patches2413[D->R[J+0x30]>>4]);
-
   /* Convert channel freq/volume changes into Sound() calls */
   for(J=0,I=D->Changed;I&&(J<YM2413_CHANNELS);++J,I>>=1)
     if(I&1) Sound(J+D->First,D->Freq[J],D->Volume[J]);
 
-  /* If there were any changes to the drums... */
-  I=D->DChanged;
-  J=D->R[0x0E];
-
-  D->Changed=D->PChanged=D->DChanged=0x000;
+  D->Changed=0x000;
 }

--- a/EMULib/YM2413.h
+++ b/EMULib/YM2413.h
@@ -42,8 +42,8 @@ typedef struct
   int Volume[YM2413_CHANNELS]; /* Volumes (0..255)           */
   int First;                   /* First used Sound() channel */
   int Changed;                 /* Bitmap of changed channels */
-  int PChanged;                /* Bitmap of changed patches  */
-  int DChanged;                /* Bitmap of changed drums    */
+  int _old1;                   /* unused                     */
+  int _old2;                   /* unused                     */
   byte Sync;                   /* YM2413_SYNC/YM2413_ASYNC   */
   byte Latch;                  /* Latch for the register num */
 } YM2413;

--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ Video: 16bpp RGB565 (PSP: BGR565, PS2: BGR555) 272x228 (544x228 in 512px MSX2 sc
 - horizontal: 256 or 512 (textmode: 32, 40 or 80 columns)
 - vertical: 192 or 212
 
-Audio: rendered in 48kHz 16b mono.
-fMSX emulates PSG, SCC and FM-PAC.
+Audio: rendered in 48kHz 16b signed mono.
+fMSX emulates PSG, SCC and FM-PAC (without drums & instruments).
 
 Framerate: NTSC (US/JP) implies 60Hz - thus 60FPS, PAL (EU) implies 50Hz (=50FPS). Gameplay and audio actually becomes 17% slower when switching from NTSC to PAL - just like on a real MSX.
 

--- a/fMSX/MSX.c
+++ b/fMSX/MSX.c
@@ -2011,8 +2011,8 @@ word LoopZ80(Z80 *R)
     /* Update AY8910 state */
     Loop8910(&PSG,J);
 
-    /* Flush changes to sound channels, only hit drums once a frame */
-    Sync8910(&PSG,AY8910_FLUSH|(!ScanLine&&OPTION(MSX_DRUMS)? AY8910_DRUMS:0));
+    /* Flush changes to sound channels */
+    Sync8910(&PSG,AY8910_FLUSH);
 
     // fmsx-libretro: do not sync SCC & FM-PAC every 8 scanlines; causes interference
   }
@@ -3328,8 +3328,6 @@ unsigned int LoadState(unsigned char *Buf,unsigned int MaxSize)
   SCChip.Changed  = (1<<SCC_CHANNELS)-1;
   SCChip.WChanged = (1<<SCC_CHANNELS)-1;
   OPLL.Changed    = (1<<YM2413_CHANNELS)-1;
-  OPLL.PChanged   = (1<<YM2413_CHANNELS)-1;
-  OPLL.DChanged   = (1<<YM2413_CHANNELS)-1;
 
   /* Return amount of data read */
   return(Size);

--- a/fMSX/MSX.h
+++ b/fMSX/MSX.h
@@ -156,7 +156,7 @@ extern "C" {
 #define MSX_AUTOFIREA 0x01000000 /* Autofire joystick FIRE-A */
 #define MSX_AUTOFIREB 0x02000000 /* Autofire joystick FIRE-B */
 #define MSX_AUTOSPACE 0x04000000 /* Autofire SPACE button    */
-#define MSX_DRUMS     0x08000000 /* Hit MIDI drums for noise */
+#define MSX_OBSOLETE  0x08000000 /* - removed from fmsx-lr - */
 #define MSX_PATCHBDOS 0x10000000 /* Patch DiskROM routines   */
 #define MSX_FIXEDFONT 0x20000000 /* Use fixed 8x8 text font  */
 #define MSX_MSXDOS2   0x40000000 /* Load MSXDOS2 ROM on boot */


### PR DESCRIPTION
finalize removal of "MIDI logging":
- remove AY8910_DRUMS, MSX_DRUMS & various other obsolete MIDI #defines
- document limitations of fMSX sound emulation & channel usage
- remove PChanged (patch, i.e., instrument) & DChanged (drum) attributes of OPLL; both were only used for MIDI logging (fMSX/X) or actual MIDI playback (fMSX/Win) - which hardly sounds like the real thing
- remove 3 obsolete tables for OPLL (YM2413)

Fixes #68.

Fixes #70. Well, actually not, but let's close that issue as well, so that we're down to the single digit range for issue count ;)
