### PR TITLE
disk updates dirty checking, and extend keymap

### DIFF
--- a/EMULib/FDIDisk.c
+++ b/EMULib/FDIDisk.c
@@ -99,6 +99,7 @@ void InitFDI(FDIDisk *D)
   D->Tracks   = 0;
   D->Sectors  = 0;
   D->SecSize  = 0;
+  D->Dirty    = 0;
 }
 
 /** EjectFDI() ***********************************************/
@@ -920,6 +921,7 @@ int SaveFDI(FDIDisk *D,const char *FileName,int Format)
   }
 
   /* Done */
+  D->Dirty=0;
   rfclose(F);
   return(Result);
 }

--- a/EMULib/FDIDisk.h
+++ b/EMULib/FDIDisk.h
@@ -41,8 +41,6 @@ extern "C" {
 
 #define SEEK_DELETED (0x40000000)
 
-#define DataFDI(D) ((D)->Data+(D)->Data[10]+((int)((D)->Data[11])<<8))
-
 #define NUM_FDI_DRIVES 4
 
 #ifndef BYTE_TYPE_DEFINED
@@ -67,6 +65,7 @@ typedef struct
 
   byte Header[6];  /* Current header, result of SeekFDI() */
   byte Verbose;    /* 1: Print debugging messages */
+  byte Dirty;      /* 1: Data to be flushed */
 } FDIDisk;
 
 /** InitFDI() ************************************************/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Source : http://fms.komkon.org/fMSX/
 * .cas .CAS - for fMSX tape files
 * .m3u .M3U - for multidisk software
 
+The supplied location must exist and must be a readable file with one of the listed extensions. If, e.g., it points to a directory or non-existent file, 
+no image is loaded and this core will boot into MSX-BASIC. It is not possible to insert a disk into a running core.
+
 
 ## Tape (cassette) software
 Tapes are automatically started based on their detected type (binary, ASCII or BASIC).
@@ -22,7 +25,7 @@ Press F6 to rewind the tape, if that's needed.
 ## Multidisk software
 Create a textfile with extension `.m3u` and list one `.dsk` filename per line.
 The file will be resolved relative to the directory location of the `.m3u`-file.
-Absolute files are also supported; start the full path with `<drive>:` on Windows or '/' on other OSes.
+Absolute files are also supported; start the full path with `<drive>:` on Windows or `/` on other OSes.
 
 Navigate through the disk images using RetroArch hotkeys; configure these settings:
 
@@ -37,7 +40,9 @@ and/or
     input_disk_prev_btn = ".."
     input_disk_next_btn = ".."
 
-Note: images can only be swapped in the 'eject' state.
+Note: 
+* these hotkeys are by default _unmapped_
+* images can only be swapped in the 'eject' state
 
 
 ## Cheats
@@ -65,10 +70,11 @@ Specify these in your RetroArch core options, either manually or via the RetroAr
 |`fmsx_mapper_type_mode`|ROM mapper - use if a ROM does not load|Guess*&vert;Generic 8kB&vert;Generic 16kB&vert;Konami5 8kB&vert;Konami4 8kB&vert;ASCII 8kB&vert;ASCII 16kB&vert;GameMaster2&vert;FMPAC
 |`fmsx_ram_pages`|RAM size|Auto*&vert;64KB&vert;128KB&vert;256KB&vert;512KB&vert;4MB
 |`fmsx_vram_pages`|Video-RAM size|Auto*&vert;32KB&vert;64KB&vert;128KB&vert;192KB
-|`fmsx_simbdos`|Simulate BDOS DiskROM access calls|No*&vert;Yes
+|`fmsx_simbdos`|Simulate BDOS DiskROM access calls (faster, but does not support CALL FORMAT)|No*&vert;Yes
 |`fmsx_autospace`|Autofire the spacebar|No*&vert;Yes
 |`fmsx_allsprites`|Show all sprites - do not emulate VDP hardware limitation|No*&vert;Yes
 |`fmsx_font`|load a fixed text font from  RetroArch's `system_directory`|standard*&vert;DEFAULT.FNT&vert;ITALIC.FNT&vert;INTERNAT.FNT&vert;CYRILLIC.FNT&vert;KOREAN.FNT&vert;JAPANESE.FNT
+|`fmsx_flush_disk`|Save changes to .dsk image|Never*&vert;Immediate&vert;On close
 
 
 ## BIOS
@@ -145,10 +151,10 @@ User 1:
 |R2    |       Ctrl
 |L3    |         F5 *
 |R3    |     Escape
-* "Keyboard": maps host keyboard to MSX keyboard. Only on (RetroArch) platforms with a real keyboard (Linux, Windows, etc). Don't forget to press Scroll Lock to enter Game Focus Mode!
+* "Keyboard": maps host keyboard to 88-key MSX keyboard. Only on (RetroArch) platforms with a real keyboard (Linux, Windows, etc). Don't forget to press Scroll Lock to enter Game Focus Mode!
   * MSX1 & 2: US/European keyboard map, cursors, numeric pad, F1-F5
-  * MSX2+: Japanese keyboard map - see below
-  * with these special keys for all 3 MSX models:
+  * MSX2+: Japanese JIS keyboard map - see below
+  * with these special keys:
 
 |Host             | MSX
 |---|---
@@ -159,30 +165,46 @@ User 1:
 |del              |DELETE
 |home             |HOME/CLS
 |end              |SELECT
-|pageup or pause  |STOP/BREAK
-|pagedown         |COUNTRY
-
+|pause            |STOP/BREAK
+|pagedown         |CODE/COUNTRY
+|pageup           |International: DEAD-key; accents `, ´, ^ and ¨<br/>JIS: _ (underscore) and ろ
+|numpad enter     |numpad comma
 
 User 2:
 * "Joystick": map RetroPad to MSX joystick B
 
 ### MSX1/2 US/European keyboard map
-Enter accented characters (like &eacute;) with COUNTRY (page down) and graphical symbols with GRAPH (left alt).
+Enter accented characters (like &eacute;) by holding CODE/COUNTRY (page down) together with a key or by preceding a key with DEAD (page up).
+Enter graphical symbols by holding GRAPH (left alt) together with a key.
+
+There is [more information about the MSX keymap](http://map.grauw.nl/articles/keymatrix.php).
 
 ### MSX2+ Japanese keyboard map
-This is a typical MSX2+ with Japanese keyboard:
+This is a typical MSX2+ with Japanese (JIS) keyboard layout:
 ![Japanese keyboard](Japanese-MSX2+-keyboard.jpg)
 
 How to use this:
 * normal: bottomleft Roman letter/symbol
 * shift: topleft symbol
-* alt: topright symbol (without the box)
+* left alt ('GRAPH'): topright symbol (without the box)
 * KANA LOCK active: bottomright Japanese character
 * KANA LOCK active with shift: middleright Japanese character
 
 To (de)activate KANA LOCK, press page down (COUNTRY). It works just like caps lock: press and release to enable.
 
 Best enable SCREEN 1 to appreciate the full 8px width of the Japanese characters; in screen 0 characters are only 6px wide.
+
+
+## Limitations
+Not supported:
+* Turbo-R (fMSX does not implement that platform)
+* Drive B
+* Cartridge slot 2
+* Printer 
+* RS-232 serial COM
+* Mouse
+* FM-PAC drums 
+* FM-PAC instruments are replaced by triangle waves
 
 
 ## Technical details
@@ -192,7 +214,7 @@ Video: 16bpp RGB565 (PSP: BGR565, PS2: BGR555) 272x228 (544x228 in 512px MSX2 sc
 - vertical: 192 or 212
 
 Audio: rendered in 48kHz 16b signed mono.
-fMSX emulates PSG, SCC and FM-PAC (without drums & instruments).
+fMSX emulates PSG, SCC and FM-PAC.
 
 Framerate: NTSC (US/JP) implies 60Hz - thus 60FPS, PAL (EU) implies 50Hz (=50FPS). Gameplay and audio actually becomes 17% slower when switching from NTSC to PAL - just like on a real MSX.
 

--- a/fMSX/MSX.c
+++ b/fMSX/MSX.c
@@ -251,7 +251,7 @@ const byte Keys[][2] =
   { 6,0x10 },{ 7,0x10 },{ 6,0x20 },{ 6,0x40 }, /* COUNTRY,STOP,F1,F2 */
   { 6,0x80 },{ 7,0x01 },{ 7,0x02 },{ 9,0x08 }, /* F3,F4,F5,PAD0 */
   { 9,0x10 },{ 9,0x20 },{ 9,0x40 },{ 7,0x04 }, /* PAD1,PAD2,PAD3,ESCAPE */
-  { 9,0x80 },{ 10,0x01 },{ 10,0x02 },{ 10,0x04 }, /* PAD4,PAD5,PAD6,PAD7 */
+  { 9,0x80 },{10,0x01 },{10,0x02 },{10,0x04 }, /* PAD4,PAD5,PAD6,PAD7 */
   { 8,0x01 },{ 0,0x02 },{ 2,0x01 },{ 0,0x08 }, /* SPACE,[!],["],[#] */
   { 0,0x10 },{ 0,0x20 },{ 0,0x80 },{ 2,0x01 }, /* [$],[%],[&],['] */
   { 1,0x02 },{ 0,0x01 },{ 1,0x01 },{ 1,0x08 }, /* [(],[)],[*],[=] */
@@ -276,7 +276,15 @@ const byte Keys[][2] =
   { 5,0x02 },{ 5,0x04 },{ 5,0x08 },{ 5,0x10 }, /* t,u,v,w */
   { 5,0x20 },{ 5,0x40 },{ 5,0x80 },{ 1,0x20 }, /* x,y,z,[{] */
   { 1,0x10 },{ 1,0x40 },{ 2,0x02 },{ 8,0x08 }, /* [|],[}],[~],DEL */
-  { 10,0x08 },{ 10,0x10 }                      /* PAD8,PAD9 */
+  {10,0x08 },{10,0x10 },                       /* PAD8,PAD9 */
+  /* these 7 mappings are missing in fMSX */
+  { 2,0x20 }, /* Int'l: DEAD / JP: _ and ろ */
+  { 9,0x01 }, /* NUM* */
+  { 9,0x02 }, /* NUM+ */
+  { 9,0x04 }, /* NUM/ */
+  {10,0x20 }, /* NUM- */
+  {10,0x40 }, /* NUM, (not present on modern numeric pads!) */
+  {10,0x80 }  /* NUM. */
 };
 
 /** Internal Functions ***************************************/
@@ -2329,6 +2337,8 @@ byte ChangeDisk(byte N,const char *FileName)
   /* If FileName not empty, treat it as directory, otherwise new disk */
   if(P&&!(*FileName? DSKLoad(FileName,P,"MSX-DISK"):DSKCreate(P,"MSX-DISK")))
   { EjectFDI(&FDD[N]);return(0); }
+
+  FDD[N].Dirty = 1;
 
   /* Done */
   return(!!P);

--- a/fMSX/MSX.h
+++ b/fMSX/MSX.h
@@ -163,7 +163,7 @@ extern "C" {
 /*************************************************************/
 
 /** Keyboard codes and macros ********************************/
-extern const byte Keys[130][2];
+extern const byte Keys[137][2];
 extern volatile byte KeyState[16];
 
 #define KBD_SET(K)   KeyState[Keys[K][0]]&=~Keys[K][1]
@@ -201,8 +201,18 @@ extern volatile byte KeyState[16];
 #define KBD_NUMPAD6  0x1E
 #define KBD_NUMPAD7  0x1F
 #define KBD_SPACE    0x20
+/* range 0x21-0x7F: 47 regular keys (a-z, 0-9 & 11 punctuation etc.) represented by their ASCII encoding */
 #define KBD_NUMPAD8  0x80
 #define KBD_NUMPAD9  0x81
+/* these 7 mappings are missing in fMSX */
+#define KBD_DEAD     0x82  /* Int'l: DEAD (accents `, ´, ^ and ¨) / JP: _ (underscore) or ろ */
+#define KBD_NUMMUL   0x83
+#define KBD_NUMPLUS  0x84
+#define KBD_NUMDIV   0x85
+#define KBD_NUMMINUS 0x86
+#define KBD_NUMCOMMA 0x87
+#define KBD_NUMDOT   0x88
+
 /*************************************************************/
 
 /** Cassette Tapes *******************************************/

--- a/fMSX/Patch.c
+++ b/fMSX/Patch.c
@@ -69,7 +69,11 @@ byte DiskWrite(byte ID,const byte *Buf,int N)
     /* Get data pointer to requested sector */
     P = LinearFDI(&FDD[ID],N);
     /* If seek operation succeeded, write sector */
-    if(P) memcpy(P,Buf,FDD[ID].SecSize);
+    if(P)
+    {
+      memcpy(P,Buf,FDD[ID].SecSize);
+      FDD[ID].Dirty = 1;
+    }
     /* Done */
     return(!!P);
   }


### PR DESCRIPTION
Fixes #43. Well, mostly at least, by enabling disk format and storing disk changes. Also described more clearly in the readme what is, and what is not supported.

Add 7 unmapped keys: DEAD (accents; underscore-key in MSX2+ JIS mode) and 6 numeric pad keys. 
Note: Numpad period key presses seem unregistered in RA (on Linux at least)?

Fixes #44. In the sense that the readme now states that Turbo-R is out of scope; that platform is not part of fMSX.

Removed one more piece of dead code: XKeyState