### PR TITLE
fix MSX2+ colour mapping: YJK566-to-RGB565 was done via RGB332

### DIFF
--- a/EMULib/EMULib.h
+++ b/EMULib/EMULib.h
@@ -60,9 +60,6 @@
 #define SND_BITS        8
 #define SND_BUFSIZE     (1<<SND_BITS)
 
-/** RGB ******************************************************/
-#define PIXEL(R,G,B)  (pixel)(((31*(R)/255)<<11)|((63*(G)/255)<<5)|(31*(B)/255))
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/README.md
+++ b/README.md
@@ -338,6 +338,11 @@ An [example alternative palette](https://paulwratt.github.io/programmers-palette
 #ffffff
 ```
 
+Colours are rendered as RGB565 (16 bit). Due to rounding down in conversion from RGB888 32 bit, the colours mentioned above
+can lose some detail. E.g., `#2020E0` (blue) is converted for RetroArch to RGB565 (3,7,27) which, when shown on a 32b display, 
+actually displays as `#181cd8`.
+
+
 ## Developers
 Some information for developers wanting to upgrade to newer fMSX versions, or improve this port.
 

--- a/fMSX/Common.h
+++ b/fMSX/Common.h
@@ -45,16 +45,20 @@ static void ClearLine(pixel *P,pixel C)
 INLINE pixel YJKColor(int Y,int J,int K)
 {
   int R,G,B;
-		
-  R=Y+J;
-  G=Y+K;
-  B=((5*Y-2*J-K)/4);
 
-  R=R<0? 0:R>31? 31:R;
-  G=G<0? 0:G>31? 31:G;
-  B=B<0? 0:B>31? 31:B;
+  // See http://map.grauw.nl/articles/yjk/
+  // YJK566 (17 bits of information, 131072 values) translates to RGB555 (15 bits, 32768 values)
+  R=(Y+J)<<3;
+  G=(Y+K)<<3;
+  B=(5*Y-2*J-K)<<1;
 
-  return(BPal[(R&0x1C)|((G&0x1C)<<3)|(B>>3)]);
+  // .. but because of overlapping & clipping that results in 16384 + 2884 = 19268 distinct colours
+  // (SCREEN10+11 YJK466, 16bits: 8192 + 4307 = 12499, plus 16 palette colours)
+  R=R<0? 0:R>255? 255:R;
+  G=G<0? 0:G>255? 255:G;
+  B=B<0? 0:B>255? 255:B;
+
+  return PIXEL(R,G,B);
 }
 
 /** RefreshBorder() ******************************************/

--- a/libretro.c
+++ b/libretro.c
@@ -23,13 +23,13 @@
 static bool video_mode_dynamic=false;
 static unsigned frame_number=0;
 static unsigned fps;
-static uint16_t* image_buffer;
+static pixel* image_buffer;
 static unsigned image_buffer_width;
 static unsigned image_buffer_height;
 
-static uint16_t XPal[80];
-static uint16_t BPal[256];
-static uint16_t XPal0;
+static pixel XPal[80];
+static pixel BPal[256];
+static pixel XPal0;
 static bool PaletteFrozen=false;
 
 #ifndef PATH_MAX
@@ -817,7 +817,7 @@ void PutImage(void)
 
    video_cb(texture_vram_p, image_buffer_width, image_buffer_height, image_buffer_width * sizeof(uint16_t));
 #else
-   video_cb(image_buffer, image_buffer_width, image_buffer_height, image_buffer_width * sizeof(uint16_t));
+   video_cb(image_buffer, image_buffer_width, image_buffer_height, image_buffer_width * sizeof(pixel));
 #endif
    frame_number++;
 
@@ -1205,7 +1205,7 @@ bool retro_load_game(const struct retro_game_info *info)
       return false;
    }
 
-   image_buffer = (uint16_t*)malloc(640*480*sizeof(uint16_t));
+   image_buffer = (pixel*)malloc(640*480*sizeof(pixel));
 
    environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &ProgDir);
 
@@ -1290,6 +1290,7 @@ bool retro_load_game(const struct retro_game_info *info)
    for(i = 0; i < 80; i++)
       SetColor(i, 0, 0, 0);
 
+   // setup fixed SCREEN 8 palette: RGB332
    for(i = 0; i < 256; i++)
      BPal[i]=PIXEL(((i>>2)&0x07)*255/7,((i>>5)&0x07)*255/7,(i&0x03)*255/3);
 


### PR DESCRIPTION
With the intermediate step removed, the full colour fidelity now remains intact.