### PR TITLE
fix Game Master support

### DIFF
--- a/EMULib/SHA1.h
+++ b/EMULib/SHA1.h
@@ -15,5 +15,7 @@ void ResetSHA1(SHA1 *State);
 int ComputeSHA1(SHA1 *State);
 int InputSHA1(SHA1 *State,const unsigned char *Data,unsigned int Size);
 const char *OutputSHA1(SHA1 *State,char *Output,unsigned int Size);
+/* convenience method to calculate SHA1 sum of a file. Caller must free the result. Returns 0 on failure. */
+char* SHA1Sum(const char* FileName);
 
 #endif /* SHA1_H */

--- a/fMSX/MSX.h
+++ b/fMSX/MSX.h
@@ -152,6 +152,7 @@ extern "C" {
 #define MSX_GUESSB    0x00020000 /* Guess ROM mapper type B  */
 
 #define MSX_OPTIONS   0x7FFC0000 /* Miscellaneous Options:   */
+#define MSX_GMASTER   0x00400000 /* Load Game Master 1/2     */
 #define MSX_ALLSPRITE 0x00800000 /* Show ALL sprites         */
 #define MSX_AUTOFIREA 0x01000000 /* Autofire joystick FIRE-A */
 #define MSX_AUTOFIREB 0x02000000 /* Autofire joystick FIRE-B */

--- a/libretro.c
+++ b/libretro.c
@@ -510,6 +510,7 @@ void retro_set_environment(retro_environment_t cb)
       { "fmsx_ram_pages", "MSX Main Memory; Auto|64KB|128KB|256KB|512KB|4MB" },
       { "fmsx_vram_pages", "MSX Video Memory; Auto|32KB|64KB|128KB|192KB" },
       { "fmsx_log_level", "fMSX logging; Off|Info|Debug|Spam" },
+      { "fmsx_game_master", "Support Game Master; No|Yes" },
       { "fmsx_simbdos", "Simulate DiskROM disk access calls; No|Yes" },
       { "fmsx_autospace", "Use autofire on SPACE; No|Yes" },
       { "fmsx_allsprites", "Show all sprites; No|Yes" },
@@ -834,7 +835,7 @@ static void check_variables(void)
    var.key = "fmsx_mode";
    var.value = NULL;
 
-   Mode = 0;
+   Mode = MSX_MSXDOS2;
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
@@ -924,6 +925,12 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && strcmp(var.value, "Yes") == 0)
       Mode |= MSX_PATCHBDOS;
+
+   var.key = "fmsx_game_master";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && strcmp(var.value, "Yes") == 0)
+      Mode |= MSX_GMASTER;
 
    var.key = "fmsx_flush_disk";
    var.value = NULL;
@@ -1365,7 +1372,8 @@ void retro_unload_game(void)
 
 unsigned retro_get_region(void)
 {
-   return RETRO_REGION_NTSC;
+   if (fps==60) return RETRO_REGION_NTSC;
+   return RETRO_REGION_PAL;
 }
 
 void *retro_get_memory_data(unsigned id)


### PR DESCRIPTION
- make Game Master 1 & 2 loading optional
- optionally load MSXDOS2.ROM, to provide Disk BASIC 2.01
- set RA region to NTSC or PAL depending on FPS 60 or 50
- load GM & GM2 in external slot A (in B in a few cases) to enable proper function on all platforms & independent of other optionally loaded ROMs
- describe slot & memory layout for MSX1 & MSX2/2+ models as implemented by fMSX